### PR TITLE
fix mnemonic usage and proper usage of aqua/provider urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ npm install
 
 ### Set up environment variables
 
-- Set a private key and export it
+- Set a private key(by exporting env "PRIVATE_KEY") or a mnemonic (by exporting env "MNEMONIC")
 
 ```
-export MNEMONIC="XXXX"
+export PRIVATE_KEY"XXXX"
 ```
 
 - Set an RPC

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ocean-demo",
+  "name": "ocean-cli",
   "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "ocean-demo",
+      "name": "ocean-cli",
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -36,16 +36,16 @@ export class Commands {
 		this.config = config || new ConfigHelper().getConfig(network);
 		this.providerUrl = process.env.PROVIDER_URL || this.config.providerUri;
 		if (this.config.chainId === 8996 && os.type() === "Darwin") {
-			process.env.CUSTOM_PROVIDER_URL = "http://127.0.0.1:8030";
+			this.providerUrl= process.env.CUSTOM_PROVIDER_URL || "http://127.0.0.1:8030";
+		}
+		else{
+			this.providerUrl= process.env.CUSTOM_PROVIDER_URL || this.config.providerUri
 		}
 		console.log("Using Provider :", this.providerUrl);
-		process.env.CUSTOM_PROVIDER_URL &&
-			console.log(" -> MacOS provider url :", process.env.CUSTOM_PROVIDER_URL);
-		this.config.metadataCacheUri =
-			this.config.chainId === 8996 && os.type() === "Darwin"
-				? "http://127.0.0.1:5000"
-				: null;
-
+		
+		if(this.config.chainId === 8996 && os.type() === "Darwin")
+			this.config.metadataCacheUri="http://127.0.0.1:5000"
+		
 		this.aquarius = new Aquarius(
 			process.env.AQUARIUS_URL || this.config.metadataCacheUri
 		);
@@ -177,7 +177,7 @@ export class Commands {
 			this.signer,
 			this.config,
 			datatoken,
-			process.env.CUSTOM_PROVIDER_URL || this.providerUrl
+			this.providerUrl
 		);
 
 		if (!tx) {
@@ -196,7 +196,7 @@ export class Commands {
 			dataDdo.services[0].id,
 			0,
 			orderTx.transactionHash,
-			process.env.CUSTOM_PROVIDER_URL || this.providerUrl,
+			this.providerUrl,
 			this.signer
 		);
 		try {
@@ -226,7 +226,7 @@ export class Commands {
 		}
 
 		const computeEnvs = await ProviderInstance.getComputeEnvironments(
-			process.env.CUSTOM_PROVIDER_URL || this.providerUrl
+			this.providerUrl
 		);
 
 		const datatoken = new Datatoken(
@@ -260,7 +260,7 @@ export class Commands {
 				algo,
 				computeEnv.id,
 				computeValidUntil,
-				process.env.CUSTOM_PROVIDER_URL || this.providerUrl,
+				this.providerUrl,
 				await this.signer.getAddress()
 			);
 		if (
@@ -285,7 +285,7 @@ export class Commands {
 			datatoken,
 			this.config,
 			providerInitializeComputeJob?.algorithm?.providerFee,
-			process.env.CUSTOM_PROVIDER_URL || this.providerUrl
+			this.providerUrl
 		);
 		if (!algo.transferTxId) {
 			console.error(
@@ -306,7 +306,7 @@ export class Commands {
 				datatoken,
 				this.config,
 				providerInitializeComputeJob?.datasets[i].providerFee,
-				process.env.CUSTOM_PROVIDER_URL || this.providerUrl
+				this.providerUrl
 			);
 			if (!assets[i].transferTxId) {
 				console.error(
@@ -319,7 +319,7 @@ export class Commands {
 		}
 		console.log("Starting compute job ...");
 		const computeJobs = await ProviderInstance.computeStart(
-			process.env.CUSTOM_PROVIDER_URL || this.providerUrl,
+			this.providerUrl,
 			this.signer,
 			computeEnv.id,
 			assets[0],
@@ -334,7 +334,7 @@ export class Commands {
 			args[1],
 			await this.signer.getAddress(),
 			args[2],
-			process.env.CUSTOM_PROVIDER_URL || this.providerUrl,
+			this.providerUrl,
 			this.signer
 		);
 		console.log(jobStatus);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { ethers } from "ethers";
 import { Commands } from "./commands";
 
 if (!process.env.MNEMONIC && !process.env.PRIVATE_KEY) {
-	console.error("Have you forgot to set env MNEMONIC or PRIVATE_KEY?");
+	console.error("Have you forgot to set MNEMONIC or PRIVATE_KEY?");
 	process.exit(0);
 }
 if (!process.env.RPC) {
@@ -62,8 +62,10 @@ async function start() {
 	let signer
 	if (process.env.PRIVATE_KEY)
 		signer = new ethers.Wallet(process.env.MNEMONIC, provider);
-	else
+	else{
 		signer = ethers.Wallet.fromMnemonic(process.env.MNEMONIC);
+		signer = await signer.connect(provider)
+	}
 	console.log("Using account: " + (await signer.getAddress()));
 
 	const { chainId } = await signer.provider.getNetwork();

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ async function start() {
 	console.log("Using RPC: " + process.env.RPC);
 	let signer
 	if (process.env.PRIVATE_KEY)
-		signer = new ethers.Wallet(process.env.MNEMONIC, provider);
+		signer = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 	else{
 		signer = ethers.Wallet.fromMnemonic(process.env.MNEMONIC);
 		signer = await signer.connect(provider)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { ethers } from "ethers";
 import { Commands } from "./commands";
 
-if (!process.env.MNEMONIC) {
-	console.error("Have you forgot to set env MNEMONIC?");
+if (!process.env.MNEMONIC && !process.env.PRIVATE_KEY) {
+	console.error("Have you forgot to set env MNEMONIC or PRIVATE_KEY?");
 	process.exit(0);
 }
 if (!process.env.RPC) {
@@ -59,8 +59,11 @@ function help() {
 async function start() {
 	const provider = new ethers.providers.JsonRpcProvider(process.env.RPC);
 	console.log("Using RPC: " + process.env.RPC);
-
-	const signer = new ethers.Wallet(process.env.MNEMONIC, provider);
+	let signer
+	if (process.env.PRIVATE_KEY)
+		signer = new ethers.Wallet(process.env.MNEMONIC, provider);
+	else
+		signer = ethers.Wallet.fromMnemonic(process.env.MNEMONIC);
 	console.log("Using account: " + (await signer.getAddress()));
 
 	const { chainId } = await signer.provider.getNetwork();


### PR DESCRIPTION
Fixes #22 

Changes proposed in this PR:

- fix aqua & provider URL because of :
```
Using RPC: https://polygon-rpc.com/
Using account: 0xC7EC1970B09224B317c52d92f37F5e1E4fF6B687
Using Provider : https://v4.provider.oceanprotocol.com
Using Aquarius : null
Available options:
	 getDDO DID - gets DDO for an asset using the asset did
```
- 
- 