### PR TITLE
Fix/provider url override if env var is set

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -37,14 +37,24 @@ export class Commands {
 		this.signer = signer;
 		this.config = config || new ConfigHelper().getConfig(network);
 		this.providerUrl = process.env.PROVIDER_URL || this.config.providerUri;
-		if (this.config.chainId === 8996 && os.type() === "Darwin") {
+		if (
+			!process.env.PROVIDER_URL &&
+			this.config.chainId === 8996 &&
+			os.type() === "Darwin"
+		) {
 			this.macOsProviderUrl = "http://127.0.0.1:8030";
-			this.config.metadataCacheUri = "http://127.0.0.1:5000";
 		}
 		console.log("Using Provider :", this.providerUrl);
 		this.macOsProviderUrl &&
 			console.log(" -> MacOS provider url :", this.macOsProviderUrl);
 
+		if (
+			!process.env.AQUARIUS_URL &&
+			this.config.chainId === 8996 &&
+			os.type() === "Darwin"
+		) {
+			this.config.metadataCacheUri = "http://127.0.0.1:5000";
+		}
 		this.aquarius = new Aquarius(
 			process.env.AQUARIUS_URL || this.config.metadataCacheUri
 		);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -47,7 +47,6 @@ export class Commands {
 		console.log("Using Provider :", this.providerUrl);
 		this.macOsProviderUrl &&
 			console.log(" -> MacOS provider url :", this.macOsProviderUrl);
-
 		if (
 			!process.env.AQUARIUS_URL &&
 			this.config.chainId === 8996 &&


### PR DESCRIPTION
Fixes #46 .

Changes proposed in this PR:

- check if provider and aqurius env vars exist and do not override them for macOS users
