### PR TITLE
Setting up cli interactive flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,19 @@ export MNEMONIC="XXXX"
 export RPC='XXXX'
 ```
 
-- Optional set metadataCache URL if you want to use a custom Aquarius version instead of the default one.
+- Set an Ocean Node URL
+
+```
+export NODE_URL='XXXX'
+```
+
+- Optional set metadataCache URL if you want to use a custom Aquarius version instead of the default one. This will not be used if you have set an Ocean Node url.
 
 ```
 export AQUARIUS_URL='XXXX'
 ```
 
-- Optional set Provider URL if you want to use a custom Provider version instead of the default one.
+- Optional set Provider URL if you want to use a custom Provider version instead of the default one. This will not be used if you have set an Ocean Node url.
 
 ```
 export PROVIDER_URL='XXXX'

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "decimal.js": "^10.4.1",
         "enquirer": "^2.4.1",
         "ethers": "^5.7.2",
+        "figlet": "^1.7.0",
         "ts-node": "^10.9.1"
       },
       "devDependencies": {
@@ -4201,6 +4202,17 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/figlet": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.7.0.tgz",
+      "integrity": "sha512-gO8l3wvqo0V7wEFLXPbkX83b7MVjRrk1oRLfYlZXol8nEpb/ON9pcKLI4qpBv5YtOTfrINtqb7b40iYY2FTWFg==",
+      "bin": {
+        "figlet": "bin/index.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -12251,6 +12263,11 @@
       "requires": {
         "reusify": "^1.0.4"
       }
+    },
+    "figlet": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.7.0.tgz",
+      "integrity": "sha512-gO8l3wvqo0V7wEFLXPbkX83b7MVjRrk1oRLfYlZXol8nEpb/ON9pcKLI4qpBv5YtOTfrINtqb7b40iYY2FTWFg=="
     },
     "file-entry-cache": {
       "version": "6.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cross-fetch": "^3.1.5",
         "crypto-js": "^4.1.1",
         "decimal.js": "^10.4.1",
+        "enquirer": "^2.4.1",
         "ethers": "^5.7.2",
         "ts-node": "^10.9.1"
       },
@@ -1564,7 +1565,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1573,7 +1573,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2849,6 +2848,18 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/es-abstract": {
@@ -7561,7 +7572,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10184,14 +10194,12 @@
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
     },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -11180,6 +11188,15 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "requires": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
       }
     },
     "es-abstract": {
@@ -14691,7 +14708,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@oceanprotocol/contracts": "^2.0.4",
-        "@oceanprotocol/lib": "^3.3.3",
+        "@oceanprotocol/lib": "^3.4.0",
         "cross-fetch": "^3.1.5",
         "crypto-js": "^4.1.1",
         "decimal.js": "^10.4.1",
@@ -38,6 +38,12 @@
         "typescript": "^5.0.4",
         "typescript-eslint": "^7.12.0"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
+      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==",
+      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1000,17 +1006,153 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oasisprotocol/deoxysii": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@oasisprotocol/deoxysii/-/deoxysii-0.0.5.tgz",
+      "integrity": "sha512-a6wYPjk8ALDIiQW/971AKOTSTY1qSdld+Y05F44gVZvlb3FOyHfgbIxXm7CZnUG1A+jK49g5SCWYP+V3/Tc75Q==",
+      "license": "MIT",
+      "dependencies": {
+        "bsaes": "0.0.2",
+        "uint32": "^0.2.1"
+      }
+    },
+    "node_modules/@oasisprotocol/sapphire-paratime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@oasisprotocol/sapphire-paratime/-/sapphire-paratime-1.3.2.tgz",
+      "integrity": "sha512-98EQ2BrT0942B0VY50PKcJ6xmUAcz71y8OBMizP6oBJIh0+ogw/z3r5z4veJitMXM4zQbh5wOFaS9eOcKWX5FA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "1.3.2",
+        "@oasisprotocol/deoxysii": "0.0.5",
+        "cborg": "1.10.2",
+        "ethers": "6.10.0",
+        "tweetnacl": "1.0.3",
+        "type-fest": "2.19.0"
+      }
+    },
+    "node_modules/@oasisprotocol/sapphire-paratime/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oasisprotocol/sapphire-paratime/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oasisprotocol/sapphire-paratime/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "license": "MIT"
+    },
+    "node_modules/@oasisprotocol/sapphire-paratime/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/@oasisprotocol/sapphire-paratime/node_modules/ethers": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.10.0.tgz",
+      "integrity": "sha512-nMNwYHzs6V1FR3Y4cdfxSQmNgZsRj1RiTU25JwvnJLmyzw9z3SKxNc2XKDuiXXo/v9ds5Mp9m6HBabgYQQ26tA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oasisprotocol/sapphire-paratime/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "license": "0BSD"
+    },
+    "node_modules/@oasisprotocol/sapphire-paratime/node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/@oasisprotocol/sapphire-paratime/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@oasisprotocol/sapphire-paratime/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@oceanprotocol/contracts": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-2.0.4.tgz",
-      "integrity": "sha512-5+SHH0YnpAnOHv9h5xuVLo20tGLLF0utubq3+O25C3NDSaqdm7kvN3sILGxVP1MtUZgJA1yEeUsNYYv0t2jMhw=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-2.2.0.tgz",
+      "integrity": "sha512-QhewXdtTebycRSZEdkAdvJkSMMnGZyxldlw2eX4VOJto8wymyNdxuhjL/tiaZ5xO7SS5BqURricx9170hfh2kQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@oceanprotocol/lib": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.3.3.tgz",
-      "integrity": "sha512-d98X3tBsfbtUJe90wmXI2HcabE3jyY+5628md6vpuItBCnSZgHIQaFvvND2jRThNEmr+4axavylNk/BS3muA5g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.4.0.tgz",
+      "integrity": "sha512-ekdqW/wfNZ+QMcU66qu8DJLqrq1inB2BXEqRp0tz7N9lZ5S3PN5GMUJ5ifKfBPQOZkjj8zk0wB1yhC5GObpPUQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@oceanprotocol/contracts": "^2.0.3",
+        "@oasisprotocol/sapphire-paratime": "^1.3.2",
+        "@oceanprotocol/contracts": "^2.2.0",
         "cross-fetch": "^4.0.0",
         "crypto-js": "^4.1.1",
         "decimal.js": "^10.4.1",
@@ -2040,6 +2182,15 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/bsaes": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/bsaes/-/bsaes-0.0.2.tgz",
+      "integrity": "sha512-iVxJFMOvCUG85sX2UVpZ9IgvH6Jjc5xpd/W8pALvFE7zfCqHkV7hW3M2XZtpg9biPS0K4Eka96bbNNgLohcpgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uint32": "^0.2.1"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -2202,6 +2353,15 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "peer": true
+    },
+    "node_modules/cborg": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.2.tgz",
+      "integrity": "sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug==",
+      "license": "Apache-2.0",
+      "bin": {
+        "cborg": "cli.js"
+      }
     },
     "node_modules/chai": {
       "version": "4.4.1",
@@ -8353,6 +8513,12 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/uint32": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/uint32/-/uint32-0.2.1.tgz",
+      "integrity": "sha512-d3i8kc/4s1CFW5g3FctmF1Bu2GVXGBMTn82JY2BW0ZtTtI8pRx1YWGPCFBwRF4uYVSJ7ua4y+qYEPqS+x+3w7Q==",
+      "license": "Do, what You want"
+    },
     "node_modules/ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -9211,6 +9377,11 @@
     }
   },
   "dependencies": {
+    "@adraffy/ens-normalize": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
+      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -9791,17 +9962,100 @@
         "fastq": "^1.6.0"
       }
     },
+    "@oasisprotocol/deoxysii": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@oasisprotocol/deoxysii/-/deoxysii-0.0.5.tgz",
+      "integrity": "sha512-a6wYPjk8ALDIiQW/971AKOTSTY1qSdld+Y05F44gVZvlb3FOyHfgbIxXm7CZnUG1A+jK49g5SCWYP+V3/Tc75Q==",
+      "requires": {
+        "bsaes": "0.0.2",
+        "uint32": "^0.2.1"
+      }
+    },
+    "@oasisprotocol/sapphire-paratime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@oasisprotocol/sapphire-paratime/-/sapphire-paratime-1.3.2.tgz",
+      "integrity": "sha512-98EQ2BrT0942B0VY50PKcJ6xmUAcz71y8OBMizP6oBJIh0+ogw/z3r5z4veJitMXM4zQbh5wOFaS9eOcKWX5FA==",
+      "requires": {
+        "@noble/hashes": "1.3.2",
+        "@oasisprotocol/deoxysii": "0.0.5",
+        "cborg": "1.10.2",
+        "ethers": "6.10.0",
+        "tweetnacl": "1.0.3",
+        "type-fest": "2.19.0"
+      },
+      "dependencies": {
+        "@noble/curves": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+          "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+          "requires": {
+            "@noble/hashes": "1.3.2"
+          }
+        },
+        "@noble/hashes": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+        },
+        "@types/node": {
+          "version": "18.15.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+          "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+        },
+        "aes-js": {
+          "version": "4.0.0-beta.5",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+          "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+        },
+        "ethers": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.10.0.tgz",
+          "integrity": "sha512-nMNwYHzs6V1FR3Y4cdfxSQmNgZsRj1RiTU25JwvnJLmyzw9z3SKxNc2XKDuiXXo/v9ds5Mp9m6HBabgYQQ26tA==",
+          "requires": {
+            "@adraffy/ens-normalize": "1.10.0",
+            "@noble/curves": "1.2.0",
+            "@noble/hashes": "1.3.2",
+            "@types/node": "18.15.13",
+            "aes-js": "4.0.0-beta.5",
+            "tslib": "2.4.0",
+            "ws": "8.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "requires": {}
+        }
+      }
+    },
     "@oceanprotocol/contracts": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-2.0.4.tgz",
-      "integrity": "sha512-5+SHH0YnpAnOHv9h5xuVLo20tGLLF0utubq3+O25C3NDSaqdm7kvN3sILGxVP1MtUZgJA1yEeUsNYYv0t2jMhw=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/contracts/-/contracts-2.2.0.tgz",
+      "integrity": "sha512-QhewXdtTebycRSZEdkAdvJkSMMnGZyxldlw2eX4VOJto8wymyNdxuhjL/tiaZ5xO7SS5BqURricx9170hfh2kQ=="
     },
     "@oceanprotocol/lib": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.3.3.tgz",
-      "integrity": "sha512-d98X3tBsfbtUJe90wmXI2HcabE3jyY+5628md6vpuItBCnSZgHIQaFvvND2jRThNEmr+4axavylNk/BS3muA5g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.4.0.tgz",
+      "integrity": "sha512-ekdqW/wfNZ+QMcU66qu8DJLqrq1inB2BXEqRp0tz7N9lZ5S3PN5GMUJ5ifKfBPQOZkjj8zk0wB1yhC5GObpPUQ==",
       "requires": {
-        "@oceanprotocol/contracts": "^2.0.3",
+        "@oasisprotocol/sapphire-paratime": "^1.3.2",
+        "@oceanprotocol/contracts": "^2.2.0",
         "cross-fetch": "^4.0.0",
         "crypto-js": "^4.1.1",
         "decimal.js": "^10.4.1",
@@ -10573,6 +10827,14 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "bsaes": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/bsaes/-/bsaes-0.0.2.tgz",
+      "integrity": "sha512-iVxJFMOvCUG85sX2UVpZ9IgvH6Jjc5xpd/W8pALvFE7zfCqHkV7hW3M2XZtpg9biPS0K4Eka96bbNNgLohcpgQ==",
+      "requires": {
+        "uint32": "^0.2.1"
+      }
+    },
     "buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -10686,6 +10948,11 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "peer": true
+    },
+    "cborg": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.2.tgz",
+      "integrity": "sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug=="
     },
     "chai": {
       "version": "4.4.1",
@@ -15237,6 +15504,11 @@
           "dev": true
         }
       }
+    },
+    "uint32": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/uint32/-/uint32-0.2.1.tgz",
+      "integrity": "sha512-d3i8kc/4s1CFW5g3FctmF1Bu2GVXGBMTn82JY2BW0ZtTtI8pRx1YWGPCFBwRF4uYVSJ7ua4y+qYEPqS+x+3w7Q=="
     },
     "ultron": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@oceanprotocol/contracts": "^2.0.4",
-        "@oceanprotocol/lib": "^3.4.0",
+        "@oceanprotocol/lib": "^3.4.1",
         "cross-fetch": "^3.1.5",
         "crypto-js": "^4.1.1",
         "decimal.js": "^10.4.1",
@@ -1146,9 +1146,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@oceanprotocol/lib": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.4.0.tgz",
-      "integrity": "sha512-ekdqW/wfNZ+QMcU66qu8DJLqrq1inB2BXEqRp0tz7N9lZ5S3PN5GMUJ5ifKfBPQOZkjj8zk0wB1yhC5GObpPUQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.4.1.tgz",
+      "integrity": "sha512-DhdNI6CF8O7ylTWNqLEdcqP9iWKFo9FDayfJvhNTL4mgWy2N1E3qzFMbsH2NAHN3fo+PbJ2KTfedpFt24r0LhA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@oasisprotocol/sapphire-paratime": "^1.3.2",
@@ -10050,9 +10050,9 @@
       "integrity": "sha512-QhewXdtTebycRSZEdkAdvJkSMMnGZyxldlw2eX4VOJto8wymyNdxuhjL/tiaZ5xO7SS5BqURricx9170hfh2kQ=="
     },
     "@oceanprotocol/lib": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.4.0.tgz",
-      "integrity": "sha512-ekdqW/wfNZ+QMcU66qu8DJLqrq1inB2BXEqRp0tz7N9lZ5S3PN5GMUJ5ifKfBPQOZkjj8zk0wB1yhC5GObpPUQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.4.1.tgz",
+      "integrity": "sha512-DhdNI6CF8O7ylTWNqLEdcqP9iWKFo9FDayfJvhNTL4mgWy2N1E3qzFMbsH2NAHN3fo+PbJ2KTfedpFt24r0LhA==",
       "requires": {
         "@oasisprotocol/sapphire-paratime": "^1.3.2",
         "@oceanprotocol/contracts": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "cross-fetch": "^3.1.5",
     "crypto-js": "^4.1.1",
     "decimal.js": "^10.4.1",
+    "enquirer": "^2.4.1",
     "ethers": "^5.7.2",
     "ts-node": "^10.9.1"
   }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@oceanprotocol/contracts": "^2.0.4",
-    "@oceanprotocol/lib": "^3.4.0",
+    "@oceanprotocol/lib": "^3.4.1",
     "cross-fetch": "^3.1.5",
     "crypto-js": "^4.1.1",
     "decimal.js": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "decimal.js": "^10.4.1",
     "enquirer": "^2.4.1",
     "ethers": "^5.7.2",
+    "figlet": "^1.7.0",
     "ts-node": "^10.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@oceanprotocol/contracts": "^2.0.4",
-    "@oceanprotocol/lib": "^3.3.3",
+    "@oceanprotocol/lib": "^3.4.0",
     "cross-fetch": "^3.1.5",
     "crypto-js": "^4.1.1",
     "decimal.js": "^10.4.1",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -23,6 +23,7 @@ import {
 	sendTx,
 } from "@oceanprotocol/lib";
 import { Signer, ethers } from "ethers";
+import { interactiveFlow } from "./interactiveFlow";
 
 export class Commands {
 	public signer: Signer;
@@ -60,6 +61,13 @@ export class Commands {
 			process.env.AQUARIUS_URL || this.config.metadataCacheUri
 		);
 	}
+
+	// start the interactive publish flow
+	public async start() {
+		console.log("Starting the CLI flow...");
+		await interactiveFlow(); // Call the CLI logic
+	  }
+
 	// utils
 	public async sleep(ms: number) {
 		return new Promise((resolve) => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -64,7 +64,7 @@ export class Commands {
 	}
 
 	public async start() {
-		console.log('Starting the CLI flow...\n\n');
+		console.log('Starting the interactive CLI flow...\n\n');
 		const data = await interactiveFlow(this.providerUrl); // Collect data via CLI
 		await publishAsset(data, this.signer, this.config); // Publish asset with collected data
 	  }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -64,7 +64,7 @@ export class Commands {
 
 	// start the interactive publish flow
 	public async start() {
-		console.log("Starting the CLI flow...");
+		console.log("Starting the CLI flow...\n\n");
 		await interactiveFlow(); // Call the CLI logic
 	  }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -99,6 +99,7 @@ export class Commands {
 				this.providerUrl,
 				this.config,
 				this.aquarius,
+				1,
 				this.macOsProviderUrl,
 				encryptDDO
 			);
@@ -130,6 +131,7 @@ export class Commands {
 			this.providerUrl,
 			this.config,
 			this.aquarius,
+			1,
 			this.macOsProviderUrl,
 			encryptDDO
 		);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -36,9 +36,9 @@ export class Commands {
 	constructor(signer: Signer, network: string | number, config?: Config) {
 		this.signer = signer;
 		this.config = config || new ConfigHelper().getConfig(network);
-		this.providerUrl = process.env.PROVIDER_URL || this.config.providerUri;
+		this.providerUrl = process.env.NODE_URL || process.env.PROVIDER_URL || this.config.providerUri;
 		if (
-			!process.env.PROVIDER_URL &&
+			!process.env.PROVIDER_URL && !process.env.NODE_URL &&
 			this.config.chainId === 8996 &&
 			os.type() === "Darwin"
 		) {
@@ -48,18 +48,18 @@ export class Commands {
 		this.macOsProviderUrl &&
 			console.log(" -> MacOS provider url :", this.macOsProviderUrl);
 		if (
-			!process.env.AQUARIUS_URL &&
+			!process.env.AQUARIUS_URL && !process.env.NODE_URL &&
 			this.config.chainId === 8996 &&
 			os.type() === "Darwin"
 		) {
 			this.config.metadataCacheUri = "http://127.0.0.1:5000";
 		}
 		this.aquarius = new Aquarius(
-			process.env.AQUARIUS_URL || this.config.metadataCacheUri
+			process.env.NODE_URL || process.env.AQUARIUS_URL || this.config.metadataCacheUri
 		);
 		console.log(
 			"Using Aquarius :",
-			process.env.AQUARIUS_URL || this.config.metadataCacheUri
+			process.env.NODE_URL || process.env.AQUARIUS_URL || this.config.metadataCacheUri
 		);
 	}
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -24,6 +24,7 @@ import {
 } from "@oceanprotocol/lib";
 import { Signer, ethers } from "ethers";
 import { interactiveFlow } from "./interactiveFlow";
+import { publishAsset } from "./publishAsset";
 
 export class Commands {
 	public signer: Signer;
@@ -62,10 +63,10 @@ export class Commands {
 		);
 	}
 
-	// start the interactive publish flow
 	public async start() {
-		console.log("Starting the CLI flow...\n\n");
-		await interactiveFlow(); // Call the CLI logic
+		console.log('Starting the CLI flow...\n\n');
+		const data = await interactiveFlow(this.providerUrl); // Collect data via CLI
+		await publishAsset(data, this.signer, this.config); // Publish asset with collected data
 	  }
 
 	// utils

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -101,12 +101,12 @@ export async function createAsset(
 	};
 
 	let bundleNFT;
-	if (!ddo.stats.price.value) {
+	if (!ddo.stats?.price?.value) {
 		bundleNFT = await nftFactory.createNftWithDatatoken(
 			nftParamsAsset,
 			datatokenParams
 		);
-	} else if (ddo.stats.price.value === "0") {
+	} else if (ddo?.stats?.price?.value === "0") {
 		const dispenserParams: DispenserCreationParams = {
 			dispenserAddress: config.dispenserAddress,
 			maxTokens: "1",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -74,8 +74,9 @@ export async function createAsset(
 	providerUrl: string,
 	config: Config,
 	aquariusInstance: Aquarius,
+	templateIndex: number = 1,
 	macOsProviderUrl?: string,
-	encryptDDO: boolean = true
+	encryptDDO: boolean = true,
 ) {
 	const { chainId } = await owner.provider.getNetwork();
 	const nft = new Nft(owner, chainId);
@@ -85,13 +86,13 @@ export async function createAsset(
 	const nftParamsAsset: NftCreateData = {
 		name,
 		symbol,
-		templateIndex: 1,
+		templateIndex,
 		tokenURI: "aaa",
 		transferable: true,
 		owner: await owner.getAddress(),
 	};
 	const datatokenParams: DatatokenCreateParams = {
-		templateIndex: 1,
+		templateIndex,
 		cap: "100000",
 		feeAmount: "0",
 		paymentCollector: await owner.getAddress(),

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -215,7 +215,6 @@ export async function createSapphireAsset(
     encryptDDO: boolean = true,
 ) {
     const { chainId } = await owner.provider.getNetwork();
-    console.log("Chain ID: ", chainId);
     const nftFactory = new NftFactory(config.nftFactoryAddress, owner);
 
     // Wrap the signer for Sapphire
@@ -233,10 +232,8 @@ export async function createSapphireAsset(
         await owner.getAddress(),
         [await owner.getAddress(), ZERO_ADDRESS]
     );
-    console.log("Allow List Address: ", allowListAddress);
 
     ddo.chainId = parseInt(chainId.toString(10));
-    console.log("DDO Chain ID: ", ddo.chainId);
     const nftParamsAsset: NftCreateData = {
         name,
         symbol,
@@ -301,9 +298,9 @@ export async function createSapphireAsset(
     const tokenCreatedEvent = getEventFromTx(trxReceipt, "TokenCreated");
 
     const nftAddress = nftCreatedEvent.args.newTokenAddress;
-	console.log("NFT Address: ", nftAddress);
+	console.log("NFT publish with address: ", nftAddress);
     const datatokenAddressAsset = tokenCreatedEvent.args.newTokenAddress;
-	console.log("Datatoken Address: ", datatokenAddressAsset)
+	console.log("Datatoken published with address: ", datatokenAddressAsset)
 
     assetUrl.datatokenAddress = datatokenAddressAsset;
     assetUrl.nftAddress = nftAddress;
@@ -342,7 +339,6 @@ export async function createSapphireAsset(
 
     // Use Nft class to set metadata on the NFT
     const nft = new Nft(wrappedSigner, chainId);
-console.log("setting metadata")
     // Set metadata using Nft
     await nft.setMetadata(
         nftAddress,
@@ -354,10 +350,8 @@ console.log("setting metadata")
         metadata,
         metadataHash
     );
-	console.log('metadata updated')
 
     // Use Datatoken4 for file object
-	console.log('Use Datatoken4 for file object')
     const datatoken = new Datatoken4(
         wrappedSigner,
         ethers.utils.toUtf8Bytes(JSON.stringify(assetUrl.files)),
@@ -366,18 +360,15 @@ console.log("setting metadata")
     );
 
     // Set file object
-	console.log('Set file object')
     await datatoken.setFileObject(datatokenAddressAsset, await wrappedSigner.getAddress());
 
     // Set allow list for the datatoken
-	console.log('Set allow list for the datatoken')
     await datatoken.setAllowListContract(
         datatokenAddressAsset,
         allowListAddress,
         await wrappedSigner.getAddress()
     );
 
-	console.log('returning ddo.id')
     return ddo.id;
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -174,7 +174,7 @@ export async function createAsset(
 	// create the files encrypted string
 	assetUrl.datatokenAddress = datatokenAddressAsset;
 	assetUrl.nftAddress = nftAddress;
-	ddo.services[0].files = await ProviderInstance.encrypt(
+	ddo.services[0].files = templateIndex === 4 ? '' : await ProviderInstance.encrypt(
 		assetUrl,
 		chainId,
 		macOsProviderUrl || providerUrl

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,9 @@ async function start() {
 	const commands = new Commands(signer, chainId);
 	const myArgs = process.argv.slice(2);
 	switch (myArgs[0]) {
+		case "start":
+			await commands.start()
+			break
 		case "getDDO":
 			await commands.getDDO(myArgs);
 			break;

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -23,7 +23,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
     console.log(chalk.cyan('Welcome to the Ocean Protocol Asset Publisher!\n'));
 
     // Prompting for basic information
-    const basicAnswers = await prompt<Omit<PublishAssetParams, 'isCharged' | 'chainId' | 'timeout'>>([
+    const basicAnswers = await prompt<Omit<PublishAssetParams, 'isCharged' | 'chainId' | 'storageType' | 'assetLocation'>>([
       {
         type: 'input',
         name: 'title',
@@ -48,24 +48,22 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
         message: chalk.green('Please provide tags to make this asset more easily discoverable (comma separated):\n'),
         required: true
       },
+      {
+        type: 'select',
+        name: 'timeout',
+        message: chalk.green('After purchasing your asset, how long should the consumer be allowed to access it for?\n'),
+        choices: [
+          {name: 'Forever', value: "0"},
+          {name: '1 day', value: "86400"},
+          {name: '1 week', value: "604800"},
+          {name: '1 month', value: "2592000"},
+          {name: '1 year', value: "31536000"}
+        ],
+        result(value) {
+          return this.choices.find(choice => choice.name === value).value;
+        }
+      },
     ]);
-
-    // Timeout prompt
-    const { timeout } = await prompt<{ timeout: number }>({
-      type: 'select',
-      name: 'timeout',
-      message: chalk.green('After purchasing your asset, how long should the consumer be allowed to access it for?\n'),
-      choices: [
-        {name: 'Forever', value: 0},
-        {name: '1 day', value: 86400},
-        {name: '1 week', value: 604800},
-        {name: '1 month', value: 2592000},
-        {name: '1 year', value: 31536000}
-      ],
-      result(value) {
-        return this.choices.find(choice => choice.name === value).value;
-      }
-    });
 
     // Storage type prompt
     const { storageType } = await prompt<{ storageType: PublishAssetParams['storageType'] }>({
@@ -135,7 +133,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
       type: 'select',
       name: 'chainId',
       message: chalk.green('What network will your asset be available for purchase through?\n'),
-      choices: [{name: 'Oasis Sapphire', value: 23295}, {name: 'Ethereum', value: 1}, {name: 'Polygon', value: 137}],
+      choices: [{name: 'Oasis Sapphire', value: 23294}, {name: 'Oasis Sapphire Testnet', value: 23295}, {name: 'Ethereum', value: 1}, {name: 'Polygon', value: 137}],
       result(value) {
         return this.choices.find(choice => choice.name === value).value;
       }
@@ -143,7 +141,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
 
     // Template prompt
     let template: number | undefined;
-    if (chainId !== 23295) {
+    if (chainId !== 23295 && chainId !== 23294) {
       const templateAnswer = await prompt<{ template: number }>({
         type: 'select',
         name: 'template',
@@ -162,7 +160,6 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
     // Combine all answers
     const allAnswers: PublishAssetParams = {
       ...basicAnswers,
-      timeout,
       storageType,
       assetLocation,
       isCharged,

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -17,6 +17,11 @@ interface Answers {
   customParameter?: string;
 }
 
+// Validation functions
+const validateIPFS = (input: string) => /^Qm[1-9A-HJ-NP-Za-km-z]{44}$/.test(input) || 'Invalid IPFS hash format.';
+const validateArweave = (input: string) => /^[a-zA-Z0-9_-]{43,}$/.test(input) || 'Invalid Arweave transaction ID format.';
+const validateURL = (input: string) => /^(https?:\/\/)[^\s/$.?#].[^\s]*$/.test(input) || 'Invalid URL format.';
+
 export async function interactiveFlow() {
   try {
     // Prompting for basic information
@@ -59,22 +64,27 @@ export async function interactiveFlow() {
       },
     ]);
 
-    // Determine assetLocation message based on storageType
+    // Determine assetLocation message and validation based on storageType
     let assetLocationMessage = 'Please provide the location of your asset:\n';
+    let validateFunction;
     if (storageType === 'IPFS') {
       assetLocationMessage = 'Please provide the IPFS hash for your asset:\n';
+      validateFunction = validateIPFS;
     } else if (storageType === 'Arweave') {
       assetLocationMessage = 'Please provide the Arweave transaction ID for your asset:\n';
+      validateFunction = validateArweave;
     } else if (storageType === 'URL') {
       assetLocationMessage = 'Please provide the URL for your asset:\n';
+      validateFunction = validateURL;
     }
 
-    // Prompt for asset location
+    // Prompt for asset location with validation
     const { assetLocation } = await prompt<{ assetLocation: string }>([
       {
         type: 'input',
         name: 'assetLocation',
         message: assetLocationMessage,
+        validate: validateFunction,
       },
     ]);
 

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -135,7 +135,8 @@ export async function interactiveFlow() {
             type: 'select',
             name: 'template',
             message: 'Which template would you like to use?\n',
-            choices: ['Template A', 'Template B', 'Template C'],
+            choices: ['Template 1 - user can buy, sell & hold datatokens.', 
+              'Template 2 - assets are purchased with basetokens and the effective supply of datatokens is is always zero.'], 
           },
         ])
       : {};

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -135,7 +135,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
       type: 'select',
       name: 'chainId',
       message: chalk.green('What network will your asset be available for purchase through?\n'),
-      choices: [{name: 'Oasis Sapphire', value: 23294}, {name: 'Ethereum', value: 1}, {name: 'Polygon', value: 137}],
+      choices: [{name: 'Oasis Sapphire', value: 23295}, {name: 'Ethereum', value: 1}, {name: 'Polygon', value: 137}],
       result(value) {
         return this.choices.find(choice => choice.name === value).value;
       }
@@ -143,7 +143,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
 
     // Template prompt
     let template: number | undefined;
-    if (chainId !== 23294) {
+    if (chainId !== 23295) {
       const templateAnswer = await prompt<{ template: number }>({
         type: 'select',
         name: 'template',

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -1,0 +1,124 @@
+import { prompt } from 'enquirer';
+
+interface Answers {
+  title: string;
+  description: string;
+  author: string;
+  tags: string;
+  accessDuration: string;
+  storageType: 'IPFS' | 'Arweave' | 'URL';
+  assetLocation: string;
+  isCharged: boolean;
+  token?: string;
+  price?: string;
+  network: 'Oasis Sapphire' | 'Ethereum' | 'Polygon';
+  template?: string;
+  showAdvanced: boolean;
+  customParameter?: string;
+}
+
+async function askQuestions() {
+  try {
+    // Prompting for basic information
+    const basicAnswers = await prompt<Answers>([
+      {
+        type: 'input',
+        name: 'title',
+        message: 'What is the title of your asset?',
+      },
+      {
+        type: 'input',
+        name: 'description',
+        message: 'Please provide a description of your asset:',
+      },
+      {
+        type: 'input',
+        name: 'author',
+        message: 'Who is the Author of this asset?',
+      },
+      {
+        type: 'input',
+        name: 'tags',
+        message: 'Please provide tags to make this asset more easily discoverable (comma separated):',
+      },
+      {
+        type: 'input',
+        name: 'accessDuration',
+        message: 'After purchasing your asset, how long should the consumer be allowed to access it for?',
+      },
+    ]);
+
+    // Prompting for technical details
+    const technicalAnswers = await prompt<Answers>([
+      {
+        type: 'select',
+        name: 'storageType',
+        message: 'How is your asset stored?',
+        choices: ['IPFS', 'Arweave', 'URL'],
+      },
+      {
+        type: 'input',
+        name: 'assetLocation',
+        message: 'Please provide the URL / hash / txID for your asset:',
+      },
+      {
+        type: 'confirm',
+        name: 'isCharged',
+        message: 'Will you charge for this asset?',
+        initial: false,
+      },
+      {
+        type: 'input',
+        name: 'token',
+        message: 'What token will you accept payments in?',
+        skip: (answers: Answers) => !answers.isCharged,
+      },
+      {
+        type: 'input',
+        name: 'price',
+        message: 'What is the price to access your asset?',
+        skip: (answers: Answers) => !answers.isCharged,
+      },
+      {
+        type: 'select',
+        name: 'network',
+        message: 'What network will your asset be available for purchase through?',
+        choices: ['Oasis Sapphire', 'Ethereum', 'Polygon'],
+        initial: 0,
+      },
+      {
+        type: 'select',
+        name: 'template',
+        message: 'Which template would you like to use?',
+        choices: ['Template A', 'Template B', 'Template C'],
+        skip: (answers: Answers) => answers.network === 'Oasis Sapphire',
+      },
+    ]);
+
+    // Prompting for advanced options
+    const advancedAnswers = await prompt<Answers>([
+      {
+        type: 'confirm',
+        name: 'showAdvanced',
+        message: 'Would you like to consider all of the advanced options for your asset?',
+        initial: false,
+      },
+      {
+        type: 'input',
+        name: 'customParameter',
+        message: 'Please provide any user-defined parameters:',
+        skip: (answers: Answers) => !answers.showAdvanced,
+      },
+    ]);
+
+    // Combine all answers
+    const allAnswers = { ...basicAnswers, ...technicalAnswers, ...advancedAnswers };
+
+    console.log('\nHere are your responses:');
+    console.log(allAnswers);
+  } catch (error) {
+    console.error('An error occurred during the prompt:', error);
+  }
+}
+
+askQuestions();

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -141,20 +141,20 @@ export async function interactiveFlow() {
       : {};
 
     // Prompting for advanced options
-    const advancedAnswers = await prompt<Partial<Answers>>([
-      {
-        type: 'confirm',
-        name: 'showAdvanced',
-        message: 'Would you like to consider all of the advanced options for your asset?\n',
-        initial: false,
-      },
-      {
-        type: 'input',
-        name: 'customParameter',
-        message: 'Please provide any user-defined parameters:\n',
-        skip: (answers: Partial<Answers>) => !answers.showAdvanced,
-      },
-    ]);
+    // const advancedAnswers = await prompt<Partial<Answers>>([
+    //   {
+    //     type: 'confirm',
+    //     name: 'showAdvanced',
+    //     message: 'Would you like to consider all of the advanced options for your asset?\n',
+    //     initial: false,
+    //   },
+    //   {
+    //     type: 'input',
+    //     name: 'customParameter',
+    //     message: 'Please provide any user-defined parameters:\n',
+    //     skip: (answers: Partial<Answers>) => !answers.showAdvanced,
+    //   },
+    // ]);
 
     // Combine all answers
     const allAnswers = { 
@@ -164,8 +164,7 @@ export async function interactiveFlow() {
       isCharged, 
       ...paymentDetails, 
       network, 
-      ...templateAnswer, 
-      ...advancedAnswers 
+      ...templateAnswer
     };
 
     console.log('\nHere are your responses:');

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -100,22 +100,24 @@ export async function interactiveFlow() {
       },
     ]);
 
-    // Continue with further technical details, conditional prompts based on isCharged
-    const paymentDetails = isCharged === 'Paid'
-      ? await prompt<Partial<Answers>>([
-          {
-            type: 'select',
-            name: 'token',
-            message: 'What token will you accept payments in?\n',
-            choices: ['OCEAN', 'H2O'],
-          },
-          {
-            type: 'input',
-            name: 'price',
-            message: 'What is the price to access your asset?\n',
-          },
-        ])
-      : {};
+    // Check if isCharged is 'Paid' to ask further questions about payment
+    let paymentDetails = {};
+    
+    if (isCharged) {
+      paymentDetails = await prompt<Partial<Answers>>([
+        {
+          type: 'select',
+          name: 'token',
+          message: 'What token will you accept payments in?\n',
+          choices: ['OCEAN', 'H2O'],
+        },
+        {
+          type: 'input',
+          name: 'price',
+          message: 'What is the price to access your asset?\n',
+        },
+      ]);
+    }
 
     // Prompt for network selection
     const { network } = await prompt<{ network: Answers['network'] }>([
@@ -135,37 +137,23 @@ export async function interactiveFlow() {
             type: 'select',
             name: 'template',
             message: 'Which template would you like to use?\n',
-            choices: ['Template 1 - user can buy, sell & hold datatokens.', 
-              'Template 2 - assets are purchased with basetokens and the effective supply of datatokens is is always zero.'], 
+            choices: [
+              'Template 1 - user can buy, sell & hold datatokens.',
+              'Template 2 - assets are purchased with basetokens and the effective supply of datatokens is is always zero.',
+            ],
           },
         ])
       : {};
 
-    // Prompting for advanced options
-    // const advancedAnswers = await prompt<Partial<Answers>>([
-    //   {
-    //     type: 'confirm',
-    //     name: 'showAdvanced',
-    //     message: 'Would you like to consider all of the advanced options for your asset?\n',
-    //     initial: false,
-    //   },
-    //   {
-    //     type: 'input',
-    //     name: 'customParameter',
-    //     message: 'Please provide any user-defined parameters:\n',
-    //     skip: (answers: Partial<Answers>) => !answers.showAdvanced,
-    //   },
-    // ]);
-
     // Combine all answers
-    const allAnswers = { 
-      ...basicAnswers, 
-      storageType, 
-      assetLocation, 
-      isCharged, 
-      ...paymentDetails, 
-      network, 
-      ...templateAnswer
+    const allAnswers = {
+      ...basicAnswers,
+      storageType,
+      assetLocation,
+      isCharged,
+      ...paymentDetails,
+      network,
+      ...templateAnswer,
     };
 
     console.log('\nHere are your responses:');

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -17,7 +17,7 @@ interface Answers {
   customParameter?: string;
 }
 
-async function askQuestions() {
+export async function interactiveFlow() {
   try {
     // Prompting for basic information
     const basicAnswers = await prompt<Answers>([
@@ -120,5 +120,3 @@ async function askQuestions() {
     console.error('An error occurred during the prompt:', error);
   }
 }
-
-askQuestions();

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -40,9 +40,15 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
       },
       {
         type: 'select',
-        name: 'accessDuration',
+        name: 'timeout',
         message: 'After purchasing your asset, how long should the consumer be allowed to access it for?\n',
-        choices: ['Forever', '1 day', '1 week', '1 month', '1 year'],
+        choices: [
+          {name: 'Forever', value: 0},
+          {name: '1 day', value: 86400},
+          {name: '1 week', value: 604800},
+          {name: '1 month', value: 2592000},
+          {name: '1 year', value: 31536000}
+        ],
         required: true
       },
     ]);
@@ -53,7 +59,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
         type: 'select',
         name: 'storageType',
         message: 'How is your asset stored?\n',
-        choices: ['IPFS', 'Arweave', 'URL'],
+        choices: [{name: 'IPFS', value: 'ipfs'}, {name: 'Arweave', value: 'arweave'}, {name: 'URL', value: 'url'}],
         required: true
       },
     ]);
@@ -118,9 +124,9 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
     const { network } = await prompt<{ network: PublishAssetParams['network'] }>([
       {
         type: 'select',
-        name: 'network',
+        name: 'chainId',
         message: 'What network will your asset be available for purchase through?\n',
-        choices: ['Oasis Sapphire', 'Ethereum', 'Polygon'],
+        choices: [{name: 'Oasis Sapphire', value: 23294}, {name: 'Ethereum', value: 1}, {name: 'Polygon', value: 137}],
         initial: 0,
         required: true
       },

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -134,8 +134,8 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
             name: 'template',
             message: 'Which template would you like to use?\n',
             choices: [
-              'Template 1 - user can buy, sell & hold datatokens.',
-              'Template 2 - assets are purchased with basetokens and the effective supply of datatokens is always zero.',
+              { name: 'Template 1 - user can buy, sell & hold datatokens.', value: 1 },
+              { name: 'Template 2 - assets are purchased with basetokens and the effective supply of datatokens is always zero.', value: 2 },
             ],
           },
         ])

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -8,7 +8,7 @@ interface Answers {
   accessDuration: 'Forever' | '1 day' | '1 week' | '1 month' | '1 year';
   storageType: 'IPFS' | 'Arweave' | 'URL';
   assetLocation: string;
-  isCharged: boolean;
+  isCharged: 'Paid' | 'Free';
   token?: string;
   price?: string;
   network: 'Oasis Sapphire' | 'Ethereum' | 'Polygon';
@@ -81,22 +81,24 @@ export async function interactiveFlow() {
     // Continue with further technical details
     const technicalAnswers = await prompt<Partial<Answers>>([
       {
-        type: 'confirm',
+        type: 'toggle',
         name: 'isCharged',
         message: 'Will you charge for this asset?\n',
-        initial: false,
+        initial: 'Paid',
+        enabled: 'Paid',
+        disabled: 'Free',
       },
       {
         type: 'input',
         name: 'token',
         message: 'What token will you accept payments in?\n',
-        skip: (answers: Partial<Answers>) => !answers.isCharged,
+        skip: (answers: Partial<Answers>) => answers.isCharged === 'Free',
       },
       {
         type: 'input',
         name: 'price',
         message: 'What is the price to access your asset?\n',
-        skip: (answers: Partial<Answers>) => !answers.isCharged,
+        skip: (answers: Partial<Answers>) => answers.isCharged === 'Free',
       },
       {
         type: 'select',

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -5,7 +5,7 @@ interface Answers {
   description: string;
   author: string;
   tags: string;
-  accessDuration: string;
+  accessDuration: 'Forever' | '1 day' | '1 week' | '1 month' | '1 year';
   storageType: 'IPFS' | 'Arweave' | 'URL';
   assetLocation: string;
   isCharged: boolean;
@@ -24,27 +24,28 @@ export async function interactiveFlow() {
       {
         type: 'input',
         name: 'title',
-        message: 'What is the title of your asset?',
+        message: 'What is the title of your asset?\n',
       },
       {
         type: 'input',
         name: 'description',
-        message: 'Please provide a description of your asset:',
+        message: 'Please provide a description of your asset:\n',
       },
       {
         type: 'input',
         name: 'author',
-        message: 'Who is the Author of this asset?',
+        message: 'Who is the Author of this asset?\n',
       },
       {
-        type: 'input',
+        type: 'list',
         name: 'tags',
-        message: 'Please provide tags to make this asset more easily discoverable (comma separated):',
+        message: 'Please provide tags to make this asset more easily discoverable (comma separated):\n',
       },
       {
-        type: 'input',
+        type: 'select',
         name: 'accessDuration',
-        message: 'After purchasing your asset, how long should the consumer be allowed to access it for?',
+        message: 'After purchasing your asset, how long should the consumer be allowed to access it for?\n',
+        choices: ['Forever', '1 day', '1 week', '1 month', '1 year'],
       },
     ]);
 
@@ -53,43 +54,43 @@ export async function interactiveFlow() {
       {
         type: 'select',
         name: 'storageType',
-        message: 'How is your asset stored?',
+        message: 'How is your asset stored?\n',
         choices: ['IPFS', 'Arweave', 'URL'],
       },
       {
         type: 'input',
         name: 'assetLocation',
-        message: 'Please provide the URL / hash / txID for your asset:',
+        message: 'Please provide the URL / hash / txID for your asset:\n',
       },
       {
         type: 'confirm',
         name: 'isCharged',
-        message: 'Will you charge for this asset?',
+        message: 'Will you charge for this asset?\n',
         initial: false,
       },
       {
         type: 'input',
         name: 'token',
-        message: 'What token will you accept payments in?',
+        message: 'What token will you accept payments in?\n',
         skip: (answers: Answers) => !answers.isCharged,
       },
       {
         type: 'input',
         name: 'price',
-        message: 'What is the price to access your asset?',
+        message: 'What is the price to access your asset?\n',
         skip: (answers: Answers) => !answers.isCharged,
       },
       {
         type: 'select',
         name: 'network',
-        message: 'What network will your asset be available for purchase through?',
+        message: 'What network will your asset be available for purchase through?\n',
         choices: ['Oasis Sapphire', 'Ethereum', 'Polygon'],
         initial: 0,
       },
       {
         type: 'select',
         name: 'template',
-        message: 'Which template would you like to use?',
+        message: 'Which template would you like to use?\n',
         choices: ['Template A', 'Template B', 'Template C'],
         skip: (answers: Answers) => answers.network === 'Oasis Sapphire',
       },
@@ -100,13 +101,13 @@ export async function interactiveFlow() {
       {
         type: 'confirm',
         name: 'showAdvanced',
-        message: 'Would you like to consider all of the advanced options for your asset?',
+        message: 'Would you like to consider all of the advanced options for your asset?\n',
         initial: false,
       },
       {
         type: 'input',
         name: 'customParameter',
-        message: 'Please provide any user-defined parameters:',
+        message: 'Please provide any user-defined parameters:\n',
         skip: (answers: Answers) => !answers.showAdvanced,
       },
     ]);

--- a/src/interactiveFlow.ts
+++ b/src/interactiveFlow.ts
@@ -1,6 +1,8 @@
 // interactiveFlow.ts
 import { prompt } from 'enquirer';
 import { PublishAssetParams } from './publishAsset';
+import chalk from 'chalk';
+import figlet from 'figlet';
 
 // Validation functions
 const validateIPFS = (input: string) =>
@@ -12,30 +14,38 @@ const validateURL = (input: string) =>
 
 export async function interactiveFlow(providerUrl: string): Promise<PublishAssetParams> {
   try {
+    console.clear();
+    console.log(
+      chalk.blue(
+        figlet.textSync('Ocean CLI', { horizontalLayout: 'full' })
+      )
+    );
+    console.log(chalk.cyan('Welcome to the Ocean Protocol Asset Publisher!\n'));
+
     // Prompting for basic information
     const basicAnswers = await prompt<Omit<PublishAssetParams, 'isCharged' | 'chainId' | 'timeout'>>([
       {
         type: 'input',
         name: 'title',
-        message: 'What is the title of your asset?\n',
+        message: chalk.green('What is the title of your asset?\n'),
         required: true
       },
       {
         type: 'input',
         name: 'description',
-        message: 'Please provide a description of your asset:\n',
+        message: chalk.green('Please provide a description of your asset:\n'),
         required: true
       },
       {
         type: 'input',
         name: 'author',
-        message: 'Who is the Author of this asset?\n',
+        message: chalk.green('Who is the Author of this asset?\n'),
         required: true
       },
       {
         type: 'list',
         name: 'tags',
-        message: 'Please provide tags to make this asset more easily discoverable (comma separated):\n',
+        message: chalk.green('Please provide tags to make this asset more easily discoverable (comma separated):\n'),
         required: true
       },
     ]);
@@ -44,7 +54,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
     const { timeout } = await prompt<{ timeout: number }>({
       type: 'select',
       name: 'timeout',
-      message: 'After purchasing your asset, how long should the consumer be allowed to access it for?\n',
+      message: chalk.green('After purchasing your asset, how long should the consumer be allowed to access it for?\n'),
       choices: [
         {name: 'Forever', value: 0},
         {name: '1 day', value: 86400},
@@ -61,7 +71,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
     const { storageType } = await prompt<{ storageType: PublishAssetParams['storageType'] }>({
       type: 'select',
       name: 'storageType',
-      message: 'How is your asset stored?\n',
+      message: chalk.green('How is your asset stored?\n'),
       choices: [{name: 'IPFS', value: 'ipfs'}, {name: 'Arweave', value: 'arweave'}, {name: 'URL', value: 'url'}],
       result(value) {
         return this.choices.find(choice => choice.name === value).value;
@@ -87,7 +97,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
       {
         type: 'input',
         name: 'assetLocation',
-        message: assetLocationMessage,
+        message: chalk.green(assetLocationMessage),
         validate: validateFunction,
         required: true
       },
@@ -97,7 +107,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
     const { isCharged } = await prompt<{ isCharged: boolean }>({
       type: 'toggle',
       name: 'isCharged',
-      message: 'Will you charge for this asset?\n',
+      message: chalk.green('Will you charge for this asset?\n'),
       enabled: 'Paid',
       disabled: 'Free',
     });
@@ -109,13 +119,13 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
         {
           type: 'select',
           name: 'token',
-          message: 'What token will you accept payments in?\n',
+          message: chalk.green('What token will you accept payments in?\n'),
           choices: ['OCEAN', 'H2O'],
         },
         {
           type: 'input',
           name: 'price',
-          message: 'What is the price to access your asset?\n',
+          message: chalk.green('What is the price to access your asset?\n'),
         },
       ]);
     }
@@ -124,7 +134,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
     const { chainId } = await prompt<{ chainId: number }>({
       type: 'select',
       name: 'chainId',
-      message: 'What network will your asset be available for purchase through?\n',
+      message: chalk.green('What network will your asset be available for purchase through?\n'),
       choices: [{name: 'Oasis Sapphire', value: 23294}, {name: 'Ethereum', value: 1}, {name: 'Polygon', value: 137}],
       result(value) {
         return this.choices.find(choice => choice.name === value).value;
@@ -137,7 +147,7 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
       const templateAnswer = await prompt<{ template: number }>({
         type: 'select',
         name: 'template',
-        message: 'Which template would you like to use?\n',
+        message: chalk.green('Which template would you like to use?\n'),
         choices: [
           { name: 'Template 1 - user can buy, sell & hold datatokens.', value: 1 },
           { name: 'Template 2 - assets are purchased with basetokens and the effective supply of datatokens is always zero.', value: 2 },
@@ -162,12 +172,12 @@ export async function interactiveFlow(providerUrl: string): Promise<PublishAsset
       providerUrl
     };
 
-    console.log('\nHere are your responses:');
-    console.log(allAnswers);
+    console.log('\n' + chalk.cyan('Here are your responses:\n'));
+    console.log(chalk.yellow(JSON.stringify(allAnswers, null, 2)));
 
     return allAnswers; 
   } catch (error) {
-    console.error('An error occurred during the prompt:', error);
+    console.error(chalk.red('An error occurred during the prompt:'), error);
     throw error;
   }
 }

--- a/src/publishAsset.ts
+++ b/src/publishAsset.ts
@@ -1,3 +1,4 @@
+// src/publishAsset.ts
 import { Signer } from 'ethers';
 import {
   Config,
@@ -91,7 +92,7 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
       params.providerUrl,
       config,
       aquarius,
-      params.template
+      1
     );
 
     console.log(`Asset successfully published with DID: ${did}`);

--- a/src/publishAsset.ts
+++ b/src/publishAsset.ts
@@ -13,7 +13,7 @@ export interface PublishAssetParams {
   description: string;
   author: string;
   tags: string[];
-  timeout: number;
+  timeout: string;
   storageType: 'ipfs' | 'arweave' | 'url';
   assetLocation: string;
   isCharged: boolean;
@@ -26,11 +26,7 @@ export interface PublishAssetParams {
 
 export async function publishAsset(params: PublishAssetParams, signer: Signer, config: Config) {
   try {
-    console.log('Publishing asset using helper functions...');
-
     const aquarius = new Aquarius(config.metadataCacheUri);
-
-    console.log('asset timeout: ', params.timeout)
 
     // Prepare initial metadata for the asset
     const metadata: DDO = {
@@ -64,7 +60,7 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
           files: '',
           datatokenAddress: '0x0', // Will be updated after creating asset
           serviceEndpoint: params.providerUrl,
-          timeout: 0,
+          timeout: Number(params.timeout),
         },
       ],
       nft: {
@@ -87,7 +83,7 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
 
     let did: string;
 
-    if (params.chainId === 23295) {
+    if (params.chainId === 23295 || params.chainId === 23294) {
       // Oasis Sapphire
       console.log('Publishing to Oasis Sapphire network...');
       

--- a/src/publishAsset.ts
+++ b/src/publishAsset.ts
@@ -44,14 +44,15 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
         description: params.description,
         author: params.author,
         license: 'MIT',
-        tags: params.tags,
-        additionalInformation: {
-          accessDuration: params.accessDuration,
-          isCharged: params.isCharged,
-          token: params.token,
-          price: params.price,
-        },
+        tags: params.tags
       },
+      stats: {
+        allocated: 0,
+        orders: 0,
+        price: {
+          value: "0"
+        }
+    },
       services: [
         {
           id: 'access',
@@ -63,6 +64,15 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
           timeout: 0,
         },
       ],
+      nft: {
+        address: "",
+        name: "Ocean Data NFT",
+        symbol: "OCEAN-NFT",
+        state: 5,
+        tokenURI: "",
+        owner: "",
+        created: ""
+      }
     };
 
     // Asset URL setup based on storage type

--- a/src/publishAsset.ts
+++ b/src/publishAsset.ts
@@ -1,0 +1,140 @@
+// publishAsset.ts
+
+import { Signer, providers, ethers } from 'ethers';
+import {
+  Config,
+  Nft,
+  NftFactory,
+  DatatokenCreateParams,
+  Aquarius,
+  ProviderInstance,
+  getEventFromTx,
+  Files,
+  DDO,
+} from '@oceanprotocol/lib';
+
+export interface PublishAssetParams {
+  title: string;
+  description: string;
+  author: string;
+  tags: string[];
+  accessDuration: string;
+  storageType: 'IPFS' | 'Arweave' | 'URL';
+  assetLocation: string;
+  isCharged: 'Paid' | 'Free';
+  token?: 'OCEAN' | 'H2O';
+  price?: string;
+  network: 'Oasis Sapphire' | 'Ethereum' | 'Polygon';
+  template?: string;
+  providerUrl: string;
+}
+
+export async function publishAsset(params: PublishAssetParams, signer: Signer, config: Config) {
+  // Load configuration
+  const provider = signer.provider as providers.JsonRpcProvider;
+  const aquarius = new Aquarius(config.metadataCacheUri);
+  
+  // Set the asset files information
+  const assetFiles: Files = {
+    nftAddress: '0x0',
+    datatokenAddress: '0x0',
+    files: [{ type: 'url', url: params.assetLocation, method: 'GET' }],
+  };
+
+  // Prepare metadata for the asset
+  const metadata: DDO = {
+    '@context': ['https://w3id.org/did/v1'],
+    id: '',
+    version: '4.1.0',
+    chainId: await provider.getNetwork().then(n => n.chainId),
+    nftAddress: '0x0',
+    metadata: {
+      created: new Date().toISOString(),
+      updated: new Date().toISOString(),
+      type: 'dataset',
+      name: params.title,
+      description: params.description,
+      author: params.author,
+      license: 'MIT',
+      tags: params.tags,
+      additionalInformation: {
+        accessDuration: params.accessDuration,
+        isCharged: params.isCharged,
+        token: params.token,
+        price: params.price,
+      },
+    },
+    services: [
+      {
+        id: 'access',
+        type: 'access',
+        description: 'Access service',
+        files: '',
+        datatokenAddress: '0x0',
+        serviceEndpoint: params.providerUrl,
+        timeout: 0,
+      },
+    ],
+  };
+
+  // Create NFT and Datatoken
+  const nftFactory = new NftFactory(config.erc721FactoryAddress, signer);
+  const nftCreateData = {
+    name: params.title,
+    symbol: 'DATATOKEN',
+    templateIndex: 1,
+    tokenURI: '',
+    transferable: true,
+    owner: await signer.getAddress(),
+  };
+
+  const datatokenCreateParams: DatatokenCreateParams = {
+    templateIndex: 1,
+    cap: '100000',
+    feeAmount: '0',
+    paymentCollector: ethers.constants.AddressZero,
+    feeToken: ethers.constants.AddressZero,
+    minter: await signer.getAddress(),
+    mpFeeAddress: ethers.constants.AddressZero,
+  };
+
+  const nftWithDatatoken = await nftFactory.createNftWithDatatoken(
+    nftCreateData,
+    datatokenCreateParams
+  );
+  const nftCreatedEvent = getEventFromTx(await nftWithDatatoken.wait(), 'NFTCreated');
+  const datatokenCreatedEvent = getEventFromTx(await nftWithDatatoken.wait(), 'TokenCreated');
+
+  // Set addresses in the asset files and metadata
+  assetFiles.nftAddress = nftCreatedEvent.args.newTokenAddress;
+  assetFiles.datatokenAddress = datatokenCreatedEvent.args.newTokenAddress;
+  metadata.nftAddress = nftCreatedEvent.args.newTokenAddress;
+
+  // Encrypt the files using provider
+  metadata.services[0].files = await ProviderInstance.encrypt(
+    assetFiles,
+    metadata.chainId,
+    params.providerUrl
+  );
+
+  // Validate metadata
+  const validation = await aquarius.validate(metadata);
+  if (!validation.valid) {
+    throw new Error('Invalid asset metadata');
+  }
+
+  // Set metadata on the NFT
+  const nft = new Nft(signer, metadata.chainId);
+  await nft.setMetadata(
+    metadata.nftAddress,
+    await signer.getAddress(),
+    0,
+    params.providerUrl,
+    '',
+    ethers.utils.hexlify(2),
+    metadata,
+    validation.hash
+  );
+
+  console.log(`Asset published with DID: ${metadata.id}`);
+}

--- a/src/publishAsset.ts
+++ b/src/publishAsset.ts
@@ -111,7 +111,7 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
 
       did = await createSapphireAsset(
         params.title,
-        'DATATOKEN', // Assuming a standard symbol for now
+        'OCEAN-NFT',
         wrappedSigner,
         assetUrl,
         metadata,
@@ -125,7 +125,7 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
       // Other networks
       did = await createAsset(
         params.title,
-        'DATATOKEN', // Assuming a standard symbol for now
+        'OCEAN-NFT',
         signer,
         assetUrl,
         metadata,

--- a/src/publishAsset.ts
+++ b/src/publishAsset.ts
@@ -18,7 +18,7 @@ export interface PublishAssetParams {
   token?: 'OCEAN' | 'H2O';
   price?: string;
   network: 'Oasis Sapphire' | 'Ethereum' | 'Polygon';
-  template?: string;
+  template?: number;
   providerUrl: string;
 }
 
@@ -91,7 +91,8 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
       metadata,
       params.providerUrl,
       config,
-      aquarius
+      aquarius,
+      params.template
     );
 
     console.log(`Asset successfully published with DID: ${did}`);

--- a/src/publishAsset.ts
+++ b/src/publishAsset.ts
@@ -1,4 +1,4 @@
-import { Signer, providers } from 'ethers';
+import { Signer } from 'ethers';
 import {
   Config,
   Aquarius,
@@ -11,13 +11,13 @@ export interface PublishAssetParams {
   description: string;
   author: string;
   tags: string[];
-  accessDuration: string;
-  storageType: 'IPFS' | 'Arweave' | 'URL';
+  timeout: number;
+  storageType: 'ipfs' | 'arweave' | 'url';
   assetLocation: string;
-  isCharged: 'Paid' | 'Free';
+  isCharged: boolean;
   token?: 'OCEAN' | 'H2O';
   price?: string;
-  network: 'Oasis Sapphire' | 'Ethereum' | 'Polygon';
+  chainId: number;
   template?: number;
   providerUrl: string;
 }
@@ -26,7 +26,6 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
   try {
     console.log('Publishing asset using helper functions...');
 
-    const provider = signer.provider as providers.JsonRpcProvider;
     const aquarius = new Aquarius(config.metadataCacheUri);
 
     // Prepare initial metadata for the asset
@@ -34,7 +33,7 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
       '@context': ['https://w3id.org/did/v1'],
       id: '', // Will be updated after creating asset
       version: '4.1.0',
-      chainId: await provider.getNetwork().then(n => n.chainId),
+      chainId: params.chainId,
       nftAddress: '0x0', // Will be updated after creating asset
       metadata: {
         created: new Date().toISOString(),

--- a/src/publishAsset.ts
+++ b/src/publishAsset.ts
@@ -1,17 +1,10 @@
-// publishAsset.ts
-
-import { Signer, providers, ethers } from 'ethers';
+import { Signer, providers } from 'ethers';
 import {
   Config,
-  Nft,
-  NftFactory,
-  DatatokenCreateParams,
   Aquarius,
-  ProviderInstance,
-  getEventFromTx,
-  Files,
   DDO,
 } from '@oceanprotocol/lib';
+import { createAsset } from './helpers'; // Import the helper function
 
 export interface PublishAssetParams {
   title: string;
@@ -30,111 +23,70 @@ export interface PublishAssetParams {
 }
 
 export async function publishAsset(params: PublishAssetParams, signer: Signer, config: Config) {
-  // Load configuration
-  const provider = signer.provider as providers.JsonRpcProvider;
-  const aquarius = new Aquarius(config.metadataCacheUri);
-  
-  // Set the asset files information
-  const assetFiles: Files = {
-    nftAddress: '0x0',
-    datatokenAddress: '0x0',
-    files: [{ type: 'url', url: params.assetLocation, method: 'GET' }],
-  };
+  try {
+    console.log('Publishing asset using helper function...');
 
-  // Prepare metadata for the asset
-  const metadata: DDO = {
-    '@context': ['https://w3id.org/did/v1'],
-    id: '',
-    version: '4.1.0',
-    chainId: await provider.getNetwork().then(n => n.chainId),
-    nftAddress: '0x0',
-    metadata: {
-      created: new Date().toISOString(),
-      updated: new Date().toISOString(),
-      type: 'dataset',
-      name: params.title,
-      description: params.description,
-      author: params.author,
-      license: 'MIT',
-      tags: params.tags,
-      additionalInformation: {
-        accessDuration: params.accessDuration,
-        isCharged: params.isCharged,
-        token: params.token,
-        price: params.price,
+    const provider = signer.provider as providers.JsonRpcProvider;
+    const aquarius = new Aquarius(config.metadataCacheUri);
+
+    // Prepare metadata for the asset
+    const metadata: DDO = {
+      '@context': ['https://w3id.org/did/v1'],
+      id: '',
+      version: '4.1.0',
+      chainId: await provider.getNetwork().then(n => n.chainId),
+      nftAddress: '0x0',
+      metadata: {
+        created: new Date().toISOString(),
+        updated: new Date().toISOString(),
+        type: 'dataset',
+        name: params.title,
+        description: params.description,
+        author: params.author,
+        license: 'MIT',
+        tags: params.tags
       },
-    },
-    services: [
-      {
-        id: 'access',
-        type: 'access',
-        description: 'Access service',
-        files: '',
-        datatokenAddress: '0x0',
-        serviceEndpoint: params.providerUrl,
-        timeout: 0,
-      },
-    ],
-  };
+      stats: {
+        allocated: "0",
+        orders: "0",
+        price: {
+          value: "0"
+        }
+  },
+      services: [
+        {
+          id: 'access',
+          type: 'access',
+          description: 'Access service',
+          files: '',
+          datatokenAddress: '0x0',
+          serviceEndpoint: params.providerUrl,
+          timeout: 0,
+        },
+      ],
+    };
 
-  // Create NFT and Datatoken
-  const nftFactory = new NftFactory(config.erc721FactoryAddress, signer);
-  const nftCreateData = {
-    name: params.title,
-    symbol: 'DATATOKEN',
-    templateIndex: 1,
-    tokenURI: '',
-    transferable: true,
-    owner: await signer.getAddress(),
-  };
+    // Asset URL setup based on storage type
+    const assetUrl = {
+      nftAddress: '0x0',
+      datatokenAddress: '0x0',
+      files: [{ type: 'url', url: params.assetLocation, method: 'GET' }],
+    };
 
-  const datatokenCreateParams: DatatokenCreateParams = {
-    templateIndex: 1,
-    cap: '100000',
-    feeAmount: '0',
-    paymentCollector: ethers.constants.AddressZero,
-    feeToken: ethers.constants.AddressZero,
-    minter: await signer.getAddress(),
-    mpFeeAddress: ethers.constants.AddressZero,
-  };
+    // Call the helper function to create the asset
+    const did = await createAsset(
+      params.title,
+      'DATATOKEN', // Assuming a standard symbol for now
+      signer,
+      assetUrl,
+      metadata,
+      params.providerUrl,
+      config,
+      aquarius
+    );
 
-  const nftWithDatatoken = await nftFactory.createNftWithDatatoken(
-    nftCreateData,
-    datatokenCreateParams
-  );
-  const nftCreatedEvent = getEventFromTx(await nftWithDatatoken.wait(), 'NFTCreated');
-  const datatokenCreatedEvent = getEventFromTx(await nftWithDatatoken.wait(), 'TokenCreated');
-
-  // Set addresses in the asset files and metadata
-  assetFiles.nftAddress = nftCreatedEvent.args.newTokenAddress;
-  assetFiles.datatokenAddress = datatokenCreatedEvent.args.newTokenAddress;
-  metadata.nftAddress = nftCreatedEvent.args.newTokenAddress;
-
-  // Encrypt the files using provider
-  metadata.services[0].files = await ProviderInstance.encrypt(
-    assetFiles,
-    metadata.chainId,
-    params.providerUrl
-  );
-
-  // Validate metadata
-  const validation = await aquarius.validate(metadata);
-  if (!validation.valid) {
-    throw new Error('Invalid asset metadata');
+    console.log(`Asset successfully published with DID: ${did}`);
+  } catch (error) {
+    console.error('Error publishing asset:', error);
   }
-
-  // Set metadata on the NFT
-  const nft = new Nft(signer, metadata.chainId);
-  await nft.setMetadata(
-    metadata.nftAddress,
-    await signer.getAddress(),
-    0,
-    params.providerUrl,
-    '',
-    ethers.utils.hexlify(2),
-    metadata,
-    validation.hash
-  );
-
-  console.log(`Asset published with DID: ${metadata.id}`);
 }

--- a/src/publishAsset.ts
+++ b/src/publishAsset.ts
@@ -5,8 +5,7 @@ import {
   Aquarius,
   DDO
 } from '@oceanprotocol/lib';
-import { createAsset, createSapphireAsset, updateAssetMetadata } from './helpers';
-import * as sapphire from '@oasisprotocol/sapphire-paratime';
+import { createAsset, updateAssetMetadata } from './helpers';
 
 export interface PublishAssetParams {
   title: string;
@@ -81,30 +80,8 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
       files: [{ type: params.storageType, url: params.assetLocation, method: 'GET' }],
     };
 
-    let did: string;
-
-    if (params.chainId === 23295 || params.chainId === 23294) {
-      // Oasis Sapphire
-      console.log('Publishing to Oasis Sapphire network...');
-      
-      const wrappedSigner = sapphire.wrap(signer);
-
-      did = await createSapphireAsset(
-        params.title,
-        'OCEAN-NFT',
-        wrappedSigner,
-        assetUrl,
-        metadata,
-        params.providerUrl,
-        config,
-        aquarius,
-        params.template || 1,
-        undefined, // macOsProviderUrl
-        true // encryptDDO
-      );
-    } else {
       // Other networks
-      did = await createAsset(
+      const did = await createAsset(
         params.title,
         'OCEAN-NFT',
         signer,
@@ -115,7 +92,7 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
         aquarius,
         params.template || 1
       );
-    }
+
 
     console.log(`Asset successfully published with DID: ${did}`);
 

--- a/test/interactivePublishFlow.ts
+++ b/test/interactivePublishFlow.ts
@@ -1,0 +1,93 @@
+import { expect } from "chai";
+import { exec } from "child_process";
+import path from "path";
+
+describe("Ocean CLI Interactive Publishing", function() {
+    this.timeout(120000); // Set a longer timeout to allow for user input simulation
+
+    const projectRoot = path.resolve(__dirname, "..");
+    let publishedDid: string;
+
+    it("should publish an asset using 'npm run cli start' interactive flow", function(done) {
+        process.env.PRIVATE_KEY = "0x1d751ded5a32226054cd2e71261039b65afb9ee1c746d055dd699b1150a5befc";
+        process.env.RPC = "http://127.0.0.1:8545";
+        process.env.AQUARIUS_URL = "http://127.0.0.1:8001";
+        process.env.PROVIDER_URL = "http://127.0.0.1:8001";
+        process.env.ADDRESS_FILE = path.join(process.env.HOME || "", ".ocean/ocean-contracts/artifacts/address.json");
+
+        const child = exec(`npm run cli start`, { cwd: projectRoot });
+
+        // Simulate user input
+        const inputs = [
+            "test 123\n",
+            "description\n",
+            "me\n",
+            "test,123\n",
+            "\n", // Select default (1 day)
+            "\n", // Select default (IPFS)
+            "QmdbaSQbGU6Wo9i5LyWWVLuU8g6WrYpWh2K4Li4QuuE8Fr\n",
+            "\n", // Select default (Paid)
+            "\n", // Select default (OCEAN)
+            "100\n",
+            "\n", // Select default (Polygon)
+            "\n", // Select default (Template 2)
+        ];
+
+        let inputIndex = 0;
+        let fullOutput = "";
+
+        if (child.stdin) {
+            const inputInterval = setInterval(() => {
+                if (inputIndex < inputs.length) {
+                    child.stdin.write(inputs[inputIndex]);
+                    inputIndex++;
+                } else {
+                    clearInterval(inputInterval);
+                    if (child.stdin) child.stdin.end();
+                }
+            }, 1000); // Adjust timing as needed
+        }
+
+        child.stdout?.on('data', (data) => {
+            fullOutput += data.toString();
+        });
+
+        child.on('close', (code) => {
+            try {
+                expect(code).to.equal(0);
+                expect(fullOutput).to.contain("Asset successfully published with DID:");
+                expect(fullOutput).to.contain("Metadata successfully updated for DID:");
+                
+                const match = fullOutput.match(/did:op:[a-f0-9]{64}/);
+                if (match) {
+                    publishedDid = match[0];
+                    expect(publishedDid).to.match(/^did:op:[a-f0-9]{64}$/);
+                } else {
+                    throw new Error("DID not found in output");
+                }
+
+                done();
+            } catch (assertionError) {
+                done(assertionError);
+            }
+        });
+    });
+
+    it("should get DDO using 'npm run cli getDDO' for the published asset", function(done) {
+        exec(`npm run cli getDDO ${publishedDid}`, { cwd: projectRoot }, (error, stdout) => {
+            try {
+                expect(stdout).to.contain(`${publishedDid}`);
+                expect(stdout).to.contain("https://w3id.org/did/v1");
+                expect(stdout).to.contain("Datatoken");
+                expect(stdout).to.contain("test 123"); // Asset title
+                expect(stdout).to.contain("description"); // Asset description
+                expect(stdout).to.contain("me"); // Author
+                expect(stdout).to.contain("test"); // Tag
+                expect(stdout).to.contain("123"); // Tag
+                done();
+            } catch (assertionError) {
+                done(assertionError);
+            }
+        });
+    });
+});


### PR DESCRIPTION
Fixes #70 

Changes proposed in this PR:

- Setting up cli interactive flow
- Publishing asset
- Adding interactive flow to the system tests.

## To test (with barge):
1. run barge locally
2. run ocean node locally
3. set the envs in ocean-cli (`export NODE_URL="http://127.0.0.1:8001"`). No need to set Aquarius or provider URL anymore.
4. `npm run build && npm run cli start`

## To test (with Oasis testnet):
1. get rose tokens on the testnet using the faucet: https://faucet.testnet.oasis.dev
2. Run the node with oasis tesnet in the RPC env: `
export RPCS='{ "23295":{ "rpc":"https://testnet.sapphire.oasis.io", "chainId": 23295, "network": "sapphire-testnet", "chunkSize": 1000 }}'`
3. set the envs in ocean-cli (`export NODE_URL="http://127.0.0.1:8001"`). No need to set Aquarius or provider URL anymore.
4. `npm run build && npm run cli start`