### PR TITLE
Delete node:16 docker image from workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,6 @@ jobs:
           docker image rm node:20-alpine
           docker image rm node:18
           docker image rm node:18-alpine
-          docker image rm node:16
           docker image rm node:16-alpine
           docker image rm debian:10
           docker image rm debian:11


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- 
- 
- 