### PR TITLE
refactor fn call waitForAqua to waitForIndexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ export PROVIDER_URL='XXXX'
 export ADDRESS_FILE='path-to-address-file'
 ```
 
+- Optional set INDEXING_MAX_RETRIES to the max number of retries when waiting for an asset to be indexed. Default is 100 retries max.
+
+```
+export INDEXING_MAX_RETRIES='100'
+```
+
+- Optional set INDEXING_RETRY_INTERVAL to the interval (in miliseconds) for each retry when waiting for an asset to be indexed. Default is 3 seconds.
+
+```
+export INDEXING_RETRY_INTERVAL='3000'
+```
+
 ### Build the TypeScript code
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@oceanprotocol/contracts": "^2.0.4",
-        "@oceanprotocol/lib": "^3.4.1",
+        "@oceanprotocol/lib": "^3.4.6",
         "cross-fetch": "^3.1.5",
         "crypto-js": "^4.1.1",
         "decimal.js": "^10.4.1",
@@ -1147,10 +1147,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@oceanprotocol/lib": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.4.1.tgz",
-      "integrity": "sha512-DhdNI6CF8O7ylTWNqLEdcqP9iWKFo9FDayfJvhNTL4mgWy2N1E3qzFMbsH2NAHN3fo+PbJ2KTfedpFt24r0LhA==",
-      "license": "Apache-2.0",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.4.6.tgz",
+      "integrity": "sha512-ZG9sOrQHWN1PxPjN75RrRqEBdo1gNd2NuEKNiCLfkSbAUMh2AgHfyq6mEHCPiAxFsmsKMyvhtOif7C6BiHLMqw==",
       "dependencies": {
         "@oasisprotocol/sapphire-paratime": "^1.3.2",
         "@oceanprotocol/contracts": "^2.2.0",
@@ -10058,9 +10057,9 @@
       "integrity": "sha512-QhewXdtTebycRSZEdkAdvJkSMMnGZyxldlw2eX4VOJto8wymyNdxuhjL/tiaZ5xO7SS5BqURricx9170hfh2kQ=="
     },
     "@oceanprotocol/lib": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.4.1.tgz",
-      "integrity": "sha512-DhdNI6CF8O7ylTWNqLEdcqP9iWKFo9FDayfJvhNTL4mgWy2N1E3qzFMbsH2NAHN3fo+PbJ2KTfedpFt24r0LhA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.4.6.tgz",
+      "integrity": "sha512-ZG9sOrQHWN1PxPjN75RrRqEBdo1gNd2NuEKNiCLfkSbAUMh2AgHfyq6mEHCPiAxFsmsKMyvhtOif7C6BiHLMqw==",
       "requires": {
         "@oasisprotocol/sapphire-paratime": "^1.3.2",
         "@oceanprotocol/contracts": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@oceanprotocol/contracts": "^2.0.4",
-    "@oceanprotocol/lib": "^3.4.1",
+    "@oceanprotocol/lib": "^3.4.6",
     "cross-fetch": "^3.1.5",
     "crypto-js": "^4.1.1",
     "decimal.js": "^10.4.1",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,6 +8,8 @@ import {
 	downloadFile,
 	isOrderable,
 	getMetadataURI,
+	getIndexingWaitSettings,
+	IndexerWaitParams,
 } from "./helpers";
 import {
 	Aquarius,
@@ -34,11 +36,14 @@ export class Commands {
 	public aquarius: Aquarius;
 	public providerUrl: string;
 	public macOsProviderUrl: string;
+	// optional settings for indexing wait time
+	private indexingParams: IndexerWaitParams;
 
 	constructor(signer: Signer, network: string | number, config?: Config) {
 		this.signer = signer;
 		this.config = config || new ConfigHelper().getConfig(network);
 		this.providerUrl = process.env.NODE_URL || process.env.PROVIDER_URL || this.config.providerUri;
+		this.indexingParams = getIndexingWaitSettings();
 		if (
 			!process.env.PROVIDER_URL && !process.env.NODE_URL &&
 			this.config.chainId === 8996 &&
@@ -142,7 +147,7 @@ export class Commands {
 	}
 
 	public async editAsset(args: string[]) {
-		const asset = await this.aquarius.waitForIndexer(args[1]);
+		const asset = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
 		if (!asset) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -178,7 +183,7 @@ export class Commands {
 
 	public async getDDO(args: string[]) {
 		console.log("Resolving Asset with DID: " + args[1]);
-		const resolvedDDO = await this.aquarius.waitForIndexer(args[1]);
+		const resolvedDDO = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
 		if (!resolvedDDO) {
 			console.error(
 				"Error fetching Asset with DID: " +
@@ -189,7 +194,7 @@ export class Commands {
 	}
 
 	public async download(args: string[]) {
-		const dataDdo = await this.aquarius.waitForIndexer(args[1]);
+		const dataDdo = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
 		if (!dataDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -258,7 +263,7 @@ export class Commands {
 		const ddos = [];
 
 		for (const dataset in inputDatasets) {
-			const dataDdo = await this.aquarius.waitForIndexer(inputDatasets[dataset]);
+			const dataDdo = await this.aquarius.waitForIndexer(inputDatasets[dataset],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
 			if (!dataDdo) {
 				console.error(
 					"Error fetching DDO " + dataset[1] + ".  Does this asset exists?"
@@ -277,7 +282,7 @@ export class Commands {
 				? this.macOsProviderUrl
 				: ddos[0].services[0].serviceEndpoint;
 
-		const algoDdo = await this.aquarius.waitForIndexer(args[2]);
+		const algoDdo = await this.aquarius.waitForIndexer(args[2],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
 		if (!algoDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -436,7 +441,7 @@ export class Commands {
 	}
 
 	public async computeStop(args: string[]) {
-		const dataDdo = await this.aquarius.waitForIndexer(args[1]);
+		const dataDdo = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
 		if (!dataDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -468,7 +473,7 @@ export class Commands {
 	}
 
 	public async allowAlgo(args: string[]) {
-		const asset = await this.aquarius.waitForIndexer(args[1]);
+		const asset = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
 		if (!asset) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -491,7 +496,7 @@ export class Commands {
 			);
 			return;
 		}
-		const algoAsset = await this.aquarius.waitForIndexer(args[2]);
+		const algoAsset = await this.aquarius.waitForIndexer(args[2],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
 		if (!algoAsset) {
 			console.error(
 				"Error fetching DDO " + args[2] + ".  Does this asset exists?"
@@ -538,7 +543,7 @@ export class Commands {
 	}
 
 	public async disallowAlgo(args: string[]) {
-		const asset = await this.aquarius.waitForIndexer(args[1]);
+		const asset = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
 		if (!asset) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -603,7 +608,7 @@ export class Commands {
 		// args[3] - agreementId
 		const hasAgreementId = args.length === 4;
 		
-		const dataDdo = await this.aquarius.waitForIndexer(args[1]);
+		const dataDdo = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
 		if (!dataDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -142,7 +142,7 @@ export class Commands {
 	}
 
 	public async editAsset(args: string[]) {
-		const asset = await this.aquarius.waitForAqua(args[1]);
+		const asset = await this.aquarius.waitForIndexer(args[1]);
 		if (!asset) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -178,7 +178,7 @@ export class Commands {
 
 	public async getDDO(args: string[]) {
 		console.log("Resolving Asset with DID: " + args[1]);
-		const resolvedDDO = await this.aquarius.waitForAqua(args[1]);
+		const resolvedDDO = await this.aquarius.waitForIndexer(args[1]);
 		if (!resolvedDDO) {
 			console.error(
 				"Error fetching Asset with DID: " +
@@ -189,7 +189,7 @@ export class Commands {
 	}
 
 	public async download(args: string[]) {
-		const dataDdo = await this.aquarius.waitForAqua(args[1]);
+		const dataDdo = await this.aquarius.waitForIndexer(args[1]);
 		if (!dataDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -258,7 +258,7 @@ export class Commands {
 		const ddos = [];
 
 		for (const dataset in inputDatasets) {
-			const dataDdo = await this.aquarius.waitForAqua(inputDatasets[dataset]);
+			const dataDdo = await this.aquarius.waitForIndexer(inputDatasets[dataset]);
 			if (!dataDdo) {
 				console.error(
 					"Error fetching DDO " + dataset[1] + ".  Does this asset exists?"
@@ -277,7 +277,7 @@ export class Commands {
 				? this.macOsProviderUrl
 				: ddos[0].services[0].serviceEndpoint;
 
-		const algoDdo = await this.aquarius.waitForAqua(args[2]);
+		const algoDdo = await this.aquarius.waitForIndexer(args[2]);
 		if (!algoDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -436,7 +436,7 @@ export class Commands {
 	}
 
 	public async computeStop(args: string[]) {
-		const dataDdo = await this.aquarius.waitForAqua(args[1]);
+		const dataDdo = await this.aquarius.waitForIndexer(args[1]);
 		if (!dataDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -468,7 +468,7 @@ export class Commands {
 	}
 
 	public async allowAlgo(args: string[]) {
-		const asset = await this.aquarius.waitForAqua(args[1]);
+		const asset = await this.aquarius.waitForIndexer(args[1]);
 		if (!asset) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -491,7 +491,7 @@ export class Commands {
 			);
 			return;
 		}
-		const algoAsset = await this.aquarius.waitForAqua(args[2]);
+		const algoAsset = await this.aquarius.waitForIndexer(args[2]);
 		if (!algoAsset) {
 			console.error(
 				"Error fetching DDO " + args[2] + ".  Does this asset exists?"
@@ -538,7 +538,7 @@ export class Commands {
 	}
 
 	public async disallowAlgo(args: string[]) {
-		const asset = await this.aquarius.waitForAqua(args[1]);
+		const asset = await this.aquarius.waitForIndexer(args[1]);
 		if (!asset) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -603,7 +603,7 @@ export class Commands {
 		// args[3] - agreementId
 		const hasAgreementId = args.length === 4;
 		
-		const dataDdo = await this.aquarius.waitForAqua(args[1]);
+		const dataDdo = await this.aquarius.waitForIndexer(args[1]);
 		if (!dataDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -433,4 +433,38 @@ export function isPrivateIP(ip): boolean {
 	}
 	return ip
  }
+ // for waiting for an asset to index
+ export interface IndexerWaitParams {
+	maxRetries: number,
+	retryInterval: number
+ }
 
+ // defines how much time we wait for an asset to index + the interval for retries
+ export function getIndexingWaitSettings(): IndexerWaitParams {
+	const indexingParams: IndexerWaitParams = {
+		maxRetries: 100, // 100 retries
+		retryInterval: 3000 // retries every 3 seconds
+	}
+	try {
+
+		if(!isNaN(Number(process.env.INDEXING_RETRY_INTERVAL))) {
+			
+			indexingParams.retryInterval = Number(process.env.INDEXING_RETRY_INTERVAL)
+			if(indexingParams.retryInterval < 0) {
+				indexingParams.retryInterval = 3000
+			}
+
+		}
+		if(!isNaN(Number(process.env.INDEXING_MAX_RETRIES))) {
+			
+			indexingParams.maxRetries = Number(process.env.INDEXING_MAX_RETRIES)
+			if(indexingParams.maxRetries < 0) {
+				indexingParams.maxRetries = 100
+			}
+		}
+	}catch(err) {
+		console.error('Error getting indexing wait arguments:' , err)
+	}
+	
+	return indexingParams
+ }

--- a/src/publishAsset.ts
+++ b/src/publishAsset.ts
@@ -3,7 +3,7 @@ import { Signer } from 'ethers';
 import {
   Config,
   Aquarius,
-  DDO
+  Asset
 } from '@oceanprotocol/lib';
 import { createAsset, updateAssetMetadata } from './helpers';
 
@@ -28,7 +28,7 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
     const aquarius = new Aquarius(config.metadataCacheUri);
 
     // Prepare initial metadata for the asset
-    const metadata: DDO = {
+    const metadata: Asset = {
       '@context': ['https://w3id.org/did/v1'],
       id: '', // Will be updated after creating asset
       version: '4.1.0',
@@ -48,7 +48,7 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
         allocated: 0,
         orders: 0,
         price: {
-          value: params.isCharged ? params.price : "0"
+          value: params.isCharged ? Number(params.price) : 0
         }
       },
       services: [
@@ -70,7 +70,10 @@ export async function publishAsset(params: PublishAssetParams, signer: Signer, c
         tokenURI: "",
         owner: "",
         created: ""
-      }
+      },
+      datatokens: [],
+      event: undefined,
+      purgatory: undefined
     };
 
     // Asset URL setup based on storage type


### PR DESCRIPTION
Fixes #85 

Changes proposed in this PR:

- refactor function call (`waitForAqua` is now `waitForIndexer`)  (uses updated SDK not older versions)
- possibility to set custom `process.env` variables for wait for indexing retry interval and number of retries
