### PR TITLE
Issue 96 consumeflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           node-version: '18.19.0'
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:

--- a/metadata/simpleDownloadDataset.json
+++ b/metadata/simpleDownloadDataset.json
@@ -31,7 +31,7 @@
         "files": [
           {
             "type": "url",
-            "url": "https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-abstract10.xml.gz-rss.xml",
+            "url": "https://github.com/oceanprotocol/ocean-node/blob/main/LICENSE",
             "method": "GET"
           }
         ]

--- a/metadata/simpleDownloadDataset.json
+++ b/metadata/simpleDownloadDataset.json
@@ -31,7 +31,7 @@
         "files": [
           {
             "type": "url",
-            "url": "https://github.com/oceanprotocol/ocean-node/blob/main/LICENSE",
+            "url": "https://raw.githubusercontent.com/oceanprotocol/ocean-node/refs/heads/main/LICENSE",
             "method": "GET"
           }
         ]

--- a/test/consumeFlow.test.ts
+++ b/test/consumeFlow.test.ts
@@ -196,7 +196,7 @@ describe("Ocean CLI Publishing", function() {
                 const downloadedFileHash = computeFileHash(downloadedFilePath);
                 const originalFilePath = './metadata/LICENSE';
     
-                await downloadFile("https://github.com/oceanprotocol/ocean-node/blob/main/LICENSE", originalFilePath);
+                await downloadFile("https://raw.githubusercontent.com/oceanprotocol/ocean-node/refs/heads/main/LICENSE", originalFilePath);
                 const originalFileHash = computeFileHash(originalFilePath);
     
                 expect(downloadedFileHash).to.equal(originalFileHash);

--- a/test/consumeFlow.test.ts
+++ b/test/consumeFlow.test.ts
@@ -190,13 +190,13 @@ describe("Ocean CLI Publishing", function() {
                 expect(stdout).to.contain("File downloaded successfully");
     
                 // Path to the downloaded file
-                const downloadedFilePath = './enwiki-latest-abstract10.xml.gz-rss.xml';
+                const downloadedFilePath = './LICENSE';
     
                 // Verify the downloaded file content hash matches the original file hash
                 const downloadedFileHash = computeFileHash(downloadedFilePath);
-                const originalFilePath = './metadata/enwiki-latest-abstract10.xml.gz-rss.xml';
+                const originalFilePath = './metadata/LICENSE';
     
-                await downloadFile("https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-abstract10.xml.gz-rss.xml", originalFilePath);
+                await downloadFile("https://github.com/oceanprotocol/ocean-node/blob/main/LICENSE", originalFilePath);
                 const originalFileHash = computeFileHash(originalFilePath);
     
                 expect(downloadedFileHash).to.equal(originalFileHash);


### PR DESCRIPTION
Fixes #96 

Changes proposed in this PR:

- use a file we control for the download flow, to avoid that it gets deleted
- 
- 