### PR TITLE
Issue ddo id with lib

### DIFF
--- a/metadata/downloadAssetPaymentUSDC.json
+++ b/metadata/downloadAssetPaymentUSDC.json
@@ -2,7 +2,7 @@
     "@context": [
       "https://w3id.org/did/v1"
     ],
-    "id": "",
+    "id": "did:op",
     "nftAddress": "",
     "version": "4.1.0",
     "chainId": 80001,

--- a/metadata/downloadAssetPaymentUSDC.json
+++ b/metadata/downloadAssetPaymentUSDC.json
@@ -5,7 +5,7 @@
     "id": "did:op",
     "nftAddress": "",
     "version": "4.1.0",
-    "chainId": 80001,
+    "chainId": 8996,
     "metadata": {
       "created": "2021-12-20T14:35:20Z",
       "updated": "2021-12-20T14:35:20Z",

--- a/metadata/jsAlgo.json
+++ b/metadata/jsAlgo.json
@@ -2,7 +2,7 @@
   "@context": [
     "https://w3id.org/did/v1"
   ],
-  "id": "",
+  "id": "did:op",
   "nftAddress": "",
   "version": "4.1.0",
   "chainId": null,

--- a/metadata/jsAlgo.json
+++ b/metadata/jsAlgo.json
@@ -5,7 +5,7 @@
   "id": "did:op",
   "nftAddress": "",
   "version": "4.1.0",
-  "chainId": null,
+  "chainId": 8996,
   "metadata": {
     "created": "2023-08-01T17:09:39Z",
     "updated": "2023-08-01T17:09:39Z",

--- a/metadata/jsIPFSAlgo.json
+++ b/metadata/jsIPFSAlgo.json
@@ -5,7 +5,7 @@
     "id": "did:op",
     "nftAddress": "",
     "version": "4.1.0",
-    "chainId": null,
+    "chainId": 8996,
     "metadata": {
       "created": "2023-08-01T17:09:39Z",
       "updated": "2023-08-01T17:09:39Z",

--- a/metadata/jsIPFSAlgo.json
+++ b/metadata/jsIPFSAlgo.json
@@ -2,7 +2,7 @@
     "@context": [
       "https://w3id.org/did/v1"
     ],
-    "id": "",
+    "id": "did:op",
     "nftAddress": "",
     "version": "4.1.0",
     "chainId": null,

--- a/metadata/pythonAlgo.json
+++ b/metadata/pythonAlgo.json
@@ -2,7 +2,7 @@
   "@context": [
     "https://w3id.org/did/v1"
   ],
-  "id": "",
+  "id": "did:op",
   "nftAddress": "",
   "version": "4.1.0",
   "chainId": null,

--- a/metadata/pythonAlgo.json
+++ b/metadata/pythonAlgo.json
@@ -5,7 +5,7 @@
   "id": "did:op",
   "nftAddress": "",
   "version": "4.1.0",
-  "chainId": null,
+  "chainId": 8996,
   "metadata": {
     "created": "2023-08-01T17:09:39Z",
     "updated": "2023-08-01T17:09:39Z",

--- a/metadata/simpleComputeDataset.json
+++ b/metadata/simpleComputeDataset.json
@@ -5,7 +5,7 @@
   "id": "did:op",
   "nftAddress": "",
   "version": "4.1.0",
-  "chainId": null,
+  "chainId": 8996,
   "metadata": {
     "created": "2021-12-20T14:35:20Z",
     "updated": "2021-12-20T14:35:20Z",

--- a/metadata/simpleComputeDataset.json
+++ b/metadata/simpleComputeDataset.json
@@ -2,7 +2,7 @@
   "@context": [
     "https://w3id.org/did/v1"
   ],
-  "id": "",
+  "id": "did:op",
   "nftAddress": "",
   "version": "4.1.0",
   "chainId": null,

--- a/metadata/simpleDownloadDataset.json
+++ b/metadata/simpleDownloadDataset.json
@@ -5,7 +5,7 @@
   "id": "did:op",
   "nftAddress": "",
   "version": "4.1.0",
-  "chainId": null,
+  "chainId": 8996,
   "metadata": {
     "created": "2021-12-20T14:35:20Z",
     "updated": "2021-12-20T14:35:20Z",

--- a/metadata/simpleDownloadDataset.json
+++ b/metadata/simpleDownloadDataset.json
@@ -2,7 +2,7 @@
   "@context": [
     "https://w3id.org/did/v1"
   ],
-  "id": "",
+  "id": "did:op",
   "nftAddress": "",
   "version": "4.1.0",
   "chainId": null,

--- a/metadata/simpleIPFSComputeDataset.json
+++ b/metadata/simpleIPFSComputeDataset.json
@@ -5,7 +5,7 @@
     "id": "did:op",
     "nftAddress": "",
     "version": "4.1.0",
-    "chainId": null,
+    "chainId": 8996,
     "metadata": {
       "created": "2021-12-20T14:35:20Z",
       "updated": "2021-12-20T14:35:20Z",

--- a/metadata/simpleIPFSComputeDataset.json
+++ b/metadata/simpleIPFSComputeDataset.json
@@ -2,7 +2,7 @@
     "@context": [
       "https://w3id.org/did/v1"
     ],
-    "id": "",
+    "id": "did:op",
     "nftAddress": "",
     "version": "4.1.0",
     "chainId": null,


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

Update samples under /metadata:
- we need an id prefix for the DDO before creation (DDO.Js check ddo version and id)
- so we need to prefix the id with a dummy `did:op` on the ddo metadata sample, even before creating the DDO itself on chain (and we also need a chainId so i'm adding the dev network 8996 as default)

For references
see: 
[https://github.com/oceanprotocol/ocean.js/blob/9a3f9209a49ed6181df695d57d32ed725ee962d2/src/utils/Assets.ts#L60](https://github.com/oceanprotocol/ocean.js/blob/9a3f9209a49ed6181df695d57d32ed725ee962d2/src/utils/Assets.ts#L60)
AND
[https://github.com/oceanprotocol/ddo.js/blob/9259d32c3b15de7b76d597bfd3d9582071affc41/src/services/ddoManager.ts#L111C3-L120C2](https://github.com/oceanprotocol/ddo.js/blob/9259d32c3b15de7b76d597bfd3d9582071affc41/src/services/ddoManager.ts#L111C3-L120C2)
```
```
without an id it throws an "Unsupported version" error
This function is called right at the beginning of the `createAsset` on the SDK .. the samples don't have an id, cause we only set it afterwards (when we do the hash)... so we need at least the dummy prefix to bypass this

![Screenshot from 2025-03-20 10-47-53](https://github.com/user-attachments/assets/f3d802cc-54d4-49f5-9504-71709dfef70e)
