### PR TITLE
Remove legacy env vars like AQUARIUS and PROVIDER urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,22 +57,10 @@ export MNEMONIC="XXXX"
 export RPC='XXXX'
 ```
 
-- Set an Ocean Node URL
+- Mandatory, Set an Ocean Node URL. Ocean Nodes infrastructure is responsible for handling assets indexing and metadata caching. It replaced old Provider and Aquarius standalone apps.
 
 ```
 export NODE_URL='XXXX'
-```
-
-- Optional, set metadataCache URL if you want to use a custom Aquarius version instead of the default one. This will not be used if you have set an Ocean Node url.
-
-```
-export AQUARIUS_URL='XXXX'
-```
-
-- Optional, set Provider URL if you want to use a custom Provider version instead of the default one. This will not be used if you have set an Ocean Node url.
-
-```
-export PROVIDER_URL='XXXX'
 ```
 
 - Optional, set ADDRESS_FILE if you want to use a custom set of smart contract address

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ocean-cli",
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2002,7 +2001,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2019,7 +2017,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2036,7 +2033,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2053,7 +2049,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2070,7 +2065,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2087,7 +2081,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2104,7 +2097,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2121,7 +2113,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2138,7 +2129,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2155,7 +2145,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2172,7 +2161,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2189,7 +2177,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2206,7 +2193,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2223,7 +2209,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2240,7 +2225,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2257,7 +2241,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2274,7 +2257,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2291,7 +2273,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2308,7 +2289,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2325,7 +2305,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2342,7 +2321,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2359,7 +2337,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2376,7 +2353,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2393,7 +2369,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2410,7 +2385,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7594,7 +7568,6 @@
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
       "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9144,7 +9117,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -9295,7 +9267,6 @@
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
       "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -13798,7 +13769,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -15285,7 +15255,6 @@
       "version": "4.19.3",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
       "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.25.0",
@@ -17952,175 +17921,150 @@
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz",
       "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/android-arm": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.1.tgz",
       "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/android-arm64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz",
       "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/android-x64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.1.tgz",
       "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/darwin-arm64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
       "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/darwin-x64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz",
       "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-arm64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz",
       "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-x64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz",
       "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz",
       "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz",
       "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/linux-ia32": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz",
       "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/linux-loong64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz",
       "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/linux-mips64el": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz",
       "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/linux-ppc64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz",
       "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/linux-riscv64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz",
       "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/linux-s390x": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz",
       "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/linux-x64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz",
       "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/netbsd-arm64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz",
       "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/netbsd-x64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz",
       "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/openbsd-arm64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
       "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/openbsd-x64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz",
       "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/sunos-x64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz",
       "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/win32-arm64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz",
       "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/win32-ia32": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz",
       "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/win32-x64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz",
       "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
-      "dev": true,
       "optional": true
     },
     "@eslint-community/eslint-utils": {
@@ -21885,7 +21829,6 @@
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
       "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
-      "dev": true,
       "requires": {
         "@esbuild/aix-ppc64": "0.25.1",
         "@esbuild/android-arm": "0.25.1",
@@ -23052,7 +22995,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -23152,7 +23094,6 @@
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
       "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
-      "dev": true,
       "requires": {
         "resolve-pkg-maps": "^1.0.0"
       }
@@ -26308,8 +26249,7 @@
     "resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="
     },
     "responselike": {
       "version": "2.0.1",
@@ -27386,7 +27326,6 @@
       "version": "4.19.3",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
       "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
-      "dev": true,
       "requires": {
         "esbuild": "~0.25.0",
         "fsevents": "~2.3.3",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,11 @@ async function initializeSigner() {
     process.exit(1);
   }
 
+  if (!process.env.NODE_URL) {
+    console.error(chalk.red("Have you forgot to set env NODE_URL?"));
+    process.exit(1);
+  }
+
   const provider = new ethers.providers.JsonRpcProvider(process.env.RPC);
   let signer;
   

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,20 +4,7 @@ import { ethers } from 'ethers';
 import chalk from 'chalk';
 
 async function initializeSigner() {
-  if (!process.env.MNEMONIC && !process.env.PRIVATE_KEY) {
-    console.error(chalk.red("Have you forgot to set MNEMONIC or PRIVATE_KEY?"));
-    process.exit(1);
-  }
-  if (!process.env.RPC) {
-    console.error(chalk.red("Have you forgot to set env RPC?"));
-    process.exit(1);
-  }
-
-  if (!process.env.NODE_URL) {
-    console.error(chalk.red("Have you forgot to set env NODE_URL?"));
-    process.exit(1);
-  }
-
+  
   const provider = new ethers.providers.JsonRpcProvider(process.env.RPC);
   let signer;
   
@@ -33,6 +20,21 @@ async function initializeSigner() {
 }
 
 export async function createCLI() {
+
+  if (!process.env.MNEMONIC && !process.env.PRIVATE_KEY) {
+    console.error(chalk.red("Have you forgot to set MNEMONIC or PRIVATE_KEY?"));
+    process.exit(1);
+  }
+  if (!process.env.RPC) {
+    console.error(chalk.red("Have you forgot to set env RPC?"));
+    process.exit(1);
+  }
+
+  if (!process.env.NODE_URL) {
+    console.error(chalk.red("Have you forgot to set env NODE_URL?"));
+    process.exit(1);
+  }
+  
   const program = new Command();
 
   program

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -48,10 +48,10 @@ export class Commands {
 	}
 
 	public async start() {
-		console.log('Starting the interactive CLI flow...\n\n');
+		console.log("Starting the interactive CLI flow...\n\n");
 		const data = await interactiveFlow(this.oceanNodeUrl); // Collect data via CLI
 		await publishAsset(data, this.signer, this.config); // Publish asset with collected data
-	  }
+	}
 
 	// utils
 	public async sleep(ms: number) {
@@ -104,30 +104,35 @@ export class Commands {
 		}
 		const encryptDDO = args[2] === "false" ? false : true;
 		// add some more checks
-		try{ 
-				const algoDid = await createAssetUtil(
-					algoAsset.nft.name,
-					algoAsset.nft.symbol,
-					this.signer,
-					algoAsset.services[0].files,
-					algoAsset,
-					this.oceanNodeUrl,
-					this.config,
-					this.aquarius,
-					encryptDDO
-				);
-				// add some more checks
-		console.log("Algorithm published. DID:  " + algoDid);
-			} catch (e) {
-				console.error("Error when publishing dataset from file: " + args[1]);
-				console.error(e);
-				return;
-			}
-		
+		try {
+			const algoDid = await createAssetUtil(
+				algoAsset.nft.name,
+				algoAsset.nft.symbol,
+				this.signer,
+				algoAsset.services[0].files,
+				algoAsset,
+				this.oceanNodeUrl,
+				this.config,
+				this.aquarius,
+				encryptDDO
+			);
+			// add some more checks
+			console.log("Algorithm published. DID:  " + algoDid);
+		} catch (e) {
+			console.error("Error when publishing dataset from file: " + args[1]);
+			console.error(e);
+			return;
+		}
 	}
 
 	public async editAsset(args: string[]) {
-		const asset = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+		const asset = await this.aquarius.waitForIndexer(
+			args[1],
+			null,
+			null,
+			this.indexingParams.retryInterval,
+			this.indexingParams.maxRetries
+		);
 		if (!asset) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -162,7 +167,13 @@ export class Commands {
 
 	public async getDDO(args: string[]) {
 		console.log("Resolving Asset with DID: " + args[1]);
-		const resolvedDDO = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+		const resolvedDDO = await this.aquarius.waitForIndexer(
+			args[1],
+			null,
+			null,
+			this.indexingParams.retryInterval,
+			this.indexingParams.maxRetries
+		);
 		if (!resolvedDDO) {
 			console.error(
 				"Error fetching Asset with DID: " +
@@ -173,7 +184,13 @@ export class Commands {
 	}
 
 	public async download(args: string[]) {
-		const dataDdo = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+		const dataDdo = await this.aquarius.waitForIndexer(
+			args[1],
+			null,
+			null,
+			this.indexingParams.retryInterval,
+			this.indexingParams.maxRetries
+		);
 		if (!dataDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -181,19 +198,18 @@ export class Commands {
 			return;
 		}
 
-		const providerURI =
-			this.oceanNodeUrl && dataDdo.chainId === 8996
-				? this.oceanNodeUrl
-				: dataDdo.services[0].serviceEndpoint;
-		console.log("Downloading asset using provider: ", providerURI);
-		const datatoken = new Datatoken(this.signer, this.config.chainId, this.config);
+		const datatoken = new Datatoken(
+			this.signer,
+			this.config.chainId,
+			this.config
+		);
 
 		const tx = await orderAsset(
 			dataDdo,
 			this.signer,
 			this.config,
 			datatoken,
-			providerURI
+			this.oceanNodeUrl
 		);
 
 		if (!tx) {
@@ -210,11 +226,11 @@ export class Commands {
 			dataDdo.services[0].id,
 			0,
 			orderTx.transactionHash,
-			providerURI,
+			this.oceanNodeUrl,
 			this.signer
 		);
 		try {
-			const path = args[2] ? args[2] : '.';
+			const path = args[2] ? args[2] : ".";
 			const { filename } = await downloadFile(urlDownloadUrl, path);
 			console.log("File downloaded successfully:", path + "/" + filename);
 		} catch (e) {
@@ -223,7 +239,6 @@ export class Commands {
 	}
 
 	public async computeStart(args: string[]) {
-
 		const inputDatasetsString = args[1];
 		let inputDatasets = [];
 
@@ -234,10 +249,9 @@ export class Commands {
 			const processedInput = inputDatasetsString
 				.replaceAll("]", "")
 				.replaceAll("[", "");
-				if(processedInput.indexOf(',') > -1) {
-					inputDatasets = processedInput.split(",");
-				}
-			
+			if (processedInput.indexOf(",") > -1) {
+				inputDatasets = processedInput.split(",");
+			}
 		} else {
 			inputDatasets.push(inputDatasetsString);
 		}
@@ -245,7 +259,13 @@ export class Commands {
 		const ddos = [];
 
 		for (const dataset in inputDatasets) {
-			const dataDdo = await this.aquarius.waitForIndexer(inputDatasets[dataset],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+			const dataDdo = await this.aquarius.waitForIndexer(
+				inputDatasets[dataset],
+				null,
+				null,
+				this.indexingParams.retryInterval,
+				this.indexingParams.maxRetries
+			);
 			if (!dataDdo) {
 				console.error(
 					"Error fetching DDO " + dataset[1] + ".  Does this asset exists?"
@@ -255,19 +275,25 @@ export class Commands {
 				ddos.push(dataDdo);
 			}
 		}
-		if (inputDatasets.length > 0 && (ddos.length <= 0 || ddos.length != inputDatasets.length)) {
+		if (
+			inputDatasets.length > 0 &&
+			(ddos.length <= 0 || ddos.length != inputDatasets.length)
+		) {
 			console.error("Not all the data ddos are available.");
 			return;
 		}
-		let providerURI = this.oceanNodeUrl
-		if(ddos.length > 0) {
-			providerURI = this.oceanNodeUrl && ddos[0].chainId === 8996
-			? this.oceanNodeUrl
-			: ddos[0].services[0].serviceEndpoint;
+		let providerURI = this.oceanNodeUrl;
+		if (ddos.length > 0) {
+			providerURI = ddos[0].services[0].serviceEndpoint;
 		}
-			
 
-		const algoDdo = await this.aquarius.waitForIndexer(args[2],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+		const algoDdo = await this.aquarius.waitForIndexer(
+			args[2],
+			null,
+			null,
+			this.indexingParams.retryInterval,
+			this.indexingParams.maxRetries
+		);
 		if (!algoDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -275,9 +301,11 @@ export class Commands {
 			return;
 		}
 
-		const computeEnvs = await ProviderInstance.getComputeEnvironments(this.oceanNodeUrl);
+		const computeEnvs = await ProviderInstance.getComputeEnvironments(
+			this.oceanNodeUrl
+		);
 
-		if(!computeEnvs || computeEnvs.length  < 1) {
+		if (!computeEnvs || computeEnvs.length < 1) {
 			console.error(
 				"Error fetching compute environments. No compute environments available."
 			);
@@ -298,7 +326,7 @@ export class Commands {
 		const computeEnvID = args[3];
 		// NO chainId needed anymore (is not part of ComputeEnvironment spec anymore)
 		// const chainComputeEnvs = computeEnvs[computeEnvID]; // was algoDdo.chainId
-		let computeEnv = null;// chainComputeEnvs[0];
+		let computeEnv = null; // chainComputeEnvs[0];
 
 		if (computeEnvID && computeEnvID.length > 1) {
 			for (const index in computeEnvs) {
@@ -308,17 +336,20 @@ export class Commands {
 				}
 			}
 		}
-		if(!computeEnv || !computeEnvID) {
-			console.error("Error fetching compute environment. No compute environment matches id: ", computeEnvID);
+		if (!computeEnv || !computeEnvID) {
+			console.error(
+				"Error fetching compute environment. No compute environment matches id: ",
+				computeEnvID
+			);
 			return;
 		}
-		
+
 		const algo: ComputeAlgorithm = {
 			documentId: algoDdo.id,
 			serviceId: algoDdo.services[0].id,
-			meta: algoDdo.metadata.algorithm
+			meta: algoDdo.metadata.algorithm,
 		};
-	
+
 		const assets = [];
 		for (const dataDdo in ddos) {
 			const canStartCompute = isOrderable(
@@ -335,9 +366,8 @@ export class Commands {
 			}
 			assets.push({
 				documentId: ddos[dataDdo].id,
-				serviceId: ddos[dataDdo].services[0].id
+				serviceId: ddos[dataDdo].services[0].id,
 			});
-
 		}
 
 		console.log("Starting compute job using provider: ", providerURI);
@@ -407,7 +437,7 @@ export class Commands {
 		}
 
 		const additionalDatasets = assets.length > 1 ? assets.slice(1) : null;
-		if(assets.length >0 ) {
+		if (assets.length > 0) {
 			console.log(
 				"Starting compute job on " +
 					assets[0].documentId +
@@ -422,14 +452,16 @@ export class Commands {
 					(!additionalDatasets ? "none" : additionalDatasets[0].documentId)
 			);
 		}
-		if(additionalDatasets!==null) {
-			console.log('Adding additional datasets to dataset, according to C2D V2 specs')
-			assets.push(additionalDatasets)
+		if (additionalDatasets !== null) {
+			console.log(
+				"Adding additional datasets to dataset, according to C2D V2 specs"
+			);
+			assets.push(additionalDatasets);
 		}
 
-		const output: ComputeOutput =  {
-			metadataUri: await getMetadataURI()
-		}
+		const output: ComputeOutput = {
+			metadataUri: await getMetadataURI(),
+		};
 
 		const computeJobs = await ProviderInstance.computeStart(
 			providerURI,
@@ -443,7 +475,7 @@ export class Commands {
 			output
 		);
 
-		console.log('compute jobs: ', computeJobs)
+		console.log("compute jobs: ", computeJobs);
 
 		if (computeJobs && computeJobs[0]) {
 			const { jobId, agreementId } = computeJobs[0];
@@ -455,7 +487,6 @@ export class Commands {
 	}
 
 	public async freeComputeStart(args: string[]) {
-
 		const inputDatasetsString = args[1];
 		let inputDatasets = [];
 
@@ -466,10 +497,9 @@ export class Commands {
 			const processedInput = inputDatasetsString
 				.replaceAll("]", "")
 				.replaceAll("[", "");
-			if(processedInput.indexOf(',') > -1) {
+			if (processedInput.indexOf(",") > -1) {
 				inputDatasets = processedInput.split(",");
-			}	
-
+			}
 		} else {
 			inputDatasets.push(inputDatasetsString);
 		}
@@ -477,7 +507,13 @@ export class Commands {
 		const ddos = [];
 
 		for (const dataset in inputDatasets) {
-			const dataDdo = await this.aquarius.waitForIndexer(inputDatasets[dataset],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+			const dataDdo = await this.aquarius.waitForIndexer(
+				inputDatasets[dataset],
+				null,
+				null,
+				this.indexingParams.retryInterval,
+				this.indexingParams.maxRetries
+			);
 			if (!dataDdo) {
 				console.error(
 					"Error fetching DDO " + dataset[1] + ".  Does this asset exists?"
@@ -488,18 +524,25 @@ export class Commands {
 			}
 		}
 
-		if (inputDatasets.length >  0 && (ddos.length <= 0 || ddos.length != inputDatasets.length) ) {
+		if (
+			inputDatasets.length > 0 &&
+			(ddos.length <= 0 || ddos.length != inputDatasets.length)
+		) {
 			console.error("Not all the data ddos are available.");
 			return;
 		}
-		let providerURI = this.oceanNodeUrl
-		if(ddos.length > 0) {
-			providerURI = this.oceanNodeUrl && ddos[0].chainId === 8996
-			? this.oceanNodeUrl
-			: ddos[0].services[0].serviceEndpoint;
+		let providerURI = this.oceanNodeUrl;
+		if (ddos.length > 0) {
+			providerURI = ddos[0].services[0].serviceEndpoint;
 		}
-			
-		const algoDdo = await this.aquarius.waitForIndexer(args[2],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+
+		const algoDdo = await this.aquarius.waitForIndexer(
+			args[2],
+			null,
+			null,
+			this.indexingParams.retryInterval,
+			this.indexingParams.maxRetries
+		);
 		if (!algoDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -507,9 +550,11 @@ export class Commands {
 			return;
 		}
 
-		const computeEnvs = await ProviderInstance.getComputeEnvironments(this.oceanNodeUrl);
+		const computeEnvs = await ProviderInstance.getComputeEnvironments(
+			this.oceanNodeUrl
+		);
 
-		if(!computeEnvs || computeEnvs.length  < 1) {
+		if (!computeEnvs || computeEnvs.length < 1) {
 			console.error(
 				"Error fetching compute environments. No compute environments available."
 			);
@@ -523,7 +568,7 @@ export class Commands {
 		const computeEnvID = args[3];
 		// NO chainId needed anymore (is not part of ComputeEnvironment spec anymore)
 		// const chainComputeEnvs = computeEnvs[computeEnvID]; // was algoDdo.chainId
-		let computeEnv = null;// chainComputeEnvs[0];
+		let computeEnv = null; // chainComputeEnvs[0];
 
 		if (computeEnvID && computeEnvID.length > 1) {
 			for (const env of computeEnvs) {
@@ -534,17 +579,20 @@ export class Commands {
 			}
 		}
 
-		if(!computeEnv || !computeEnvID) {
-			console.error("Error fetching free compute environment. No free compute environment matches id: ", computeEnvID);
+		if (!computeEnv || !computeEnvID) {
+			console.error(
+				"Error fetching free compute environment. No free compute environment matches id: ",
+				computeEnvID
+			);
 			return;
 		}
-		
+
 		const algo: ComputeAlgorithm = {
 			documentId: algoDdo.id,
 			serviceId: algoDdo.services[0].id,
-			meta: algoDdo.metadata.algorithm
+			meta: algoDdo.metadata.algorithm,
 		};
-	
+
 		const assets = [];
 		for (const dataDdo in ddos) {
 			const canStartCompute = isOrderable(
@@ -561,14 +609,13 @@ export class Commands {
 			}
 			assets.push({
 				documentId: ddos[dataDdo].id,
-				serviceId: ddos[dataDdo].services[0].id
+				serviceId: ddos[dataDdo].services[0].id,
 			});
-
 		}
 
 		console.log("Starting compute job using provider: ", providerURI);
 		const additionalDatasets = assets.length > 1 ? assets.slice(1) : null;
-		if(assets.length > 0) {
+		if (assets.length > 0) {
 			console.log(
 				"Starting compute job on " +
 					assets[0].documentId +
@@ -583,15 +630,17 @@ export class Commands {
 					(!additionalDatasets ? "none" : additionalDatasets[0].documentId)
 			);
 		}
-		
-		if(additionalDatasets!==null) {
-			console.log('Adding additional datasets to dataset, according to C2D V2 specs')
-			assets.push(additionalDatasets)
+
+		if (additionalDatasets !== null) {
+			console.log(
+				"Adding additional datasets to dataset, according to C2D V2 specs"
+			);
+			assets.push(additionalDatasets);
 		}
 
-		const output: ComputeOutput =  {
-			metadataUri: await getMetadataURI()
-		}
+		const output: ComputeOutput = {
+			metadataUri: await getMetadataURI(),
+		};
 
 		const computeJobs = await ProviderInstance.freeComputeStart(
 			providerURI,
@@ -603,18 +652,24 @@ export class Commands {
 			output
 		);
 
-		console.log('compute jobs: ', computeJobs)
+		console.log("compute jobs: ", computeJobs);
 
 		if (computeJobs && computeJobs[0]) {
 			const { jobId } = computeJobs[0];
-			console.log("Compute started.  JobID: " + jobId);	
+			console.log("Compute started.  JobID: " + jobId);
 		} else {
 			console.log("Error while starting the compute job: ", computeJobs);
 		}
 	}
 
 	public async computeStop(args: string[]) {
-		const dataDdo = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+		const dataDdo = await this.aquarius.waitForIndexer(
+			args[1],
+			null,
+			null,
+			this.indexingParams.retryInterval,
+			this.indexingParams.maxRetries
+		);
 		if (!dataDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -623,22 +678,16 @@ export class Commands {
 		}
 		const hasAgreementId = args.length === 4;
 
-		const jobId = args[2]
+		const jobId = args[2];
 		let agreementId = null;
-		if(hasAgreementId) {
+		if (hasAgreementId) {
 			agreementId = args[3];
 		}
-
-		const providerURI =
-			this.oceanNodeUrl && dataDdo.chainId === 8996
-				? this.oceanNodeUrl
-				: dataDdo.services[0].serviceEndpoint;
-
 		const jobStatus = await ProviderInstance.computeStop(
 			args[1],
 			await this.signer.getAddress(),
 			jobId,
-			providerURI,
+			this.oceanNodeUrl,
 			this.signer,
 			agreementId
 		);
@@ -646,44 +695,53 @@ export class Commands {
 	}
 
 	public async getComputeEnvironments() {
-		const computeEnvs = await ProviderInstance.getComputeEnvironments(this.oceanNodeUrl);
+		const computeEnvs = await ProviderInstance.getComputeEnvironments(
+			this.oceanNodeUrl
+		);
 
-		if(!computeEnvs || computeEnvs.length  < 1) {
+		if (!computeEnvs || computeEnvs.length < 1) {
 			console.error(
 				"Error fetching compute environments. No compute environments available."
 			);
 			return;
 		}
-		console.log('Exiting compute environments: ', computeEnvs)
+		console.log("Exiting compute environments: ", computeEnvs);
 	}
 
 	public async computeStreamableLogs(args: string[]) {
-		const jobId = args[0]
-		const logsResponse = await ProviderInstance.computeStreamableLogs(this.oceanNodeUrl,this.signer,jobId,
+		const jobId = args[0];
+		const logsResponse = await ProviderInstance.computeStreamableLogs(
+			this.oceanNodeUrl,
+			this.signer,
+			jobId
 		);
-		console.log('response: ' , logsResponse)
+		console.log("response: ", logsResponse);
 
-		if(!logsResponse) {
-			console.error(
-				"Error fetching streamable logs. No logs available."
-			);
+		if (!logsResponse) {
+			console.error("Error fetching streamable logs. No logs available.");
 			return;
 		} else {
-			const stream = logsResponse as ReadableStream
-			console.log('stream: ', stream)
+			const stream = logsResponse as ReadableStream;
+			console.log("stream: ", stream);
 			const text = await new Response(stream).text();
-			console.log('Streamable Logs: ')
+			console.log("Streamable Logs: ");
 			console.log(text);
 			// for await (const value of stream) {
 			// 	// just print it to the console
 			// 	console.log(value);
 			// }
 		}
-		console.log('Exiting computeStreamableLogs: ', logsResponse)
+		console.log("Exiting computeStreamableLogs: ", logsResponse);
 	}
 
 	public async allowAlgo(args: string[]) {
-		const asset = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+		const asset = await this.aquarius.waitForIndexer(
+			args[1],
+			null,
+			null,
+			this.indexingParams.retryInterval,
+			this.indexingParams.maxRetries
+		);
 		if (!asset) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -706,7 +764,13 @@ export class Commands {
 			);
 			return;
 		}
-		const algoAsset = await this.aquarius.waitForIndexer(args[2],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+		const algoAsset = await this.aquarius.waitForIndexer(
+			args[2],
+			null,
+			null,
+			this.indexingParams.retryInterval,
+			this.indexingParams.maxRetries
+		);
 		if (!algoAsset) {
 			console.error(
 				"Error fetching DDO " + args[2] + ".  Does this asset exists?"
@@ -752,7 +816,13 @@ export class Commands {
 	}
 
 	public async disallowAlgo(args: string[]) {
-		const asset = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+		const asset = await this.aquarius.waitForIndexer(
+			args[1],
+			null,
+			null,
+			this.indexingParams.retryInterval,
+			this.indexingParams.maxRetries
+		);
 		if (!asset) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
@@ -815,26 +885,28 @@ export class Commands {
 		// args[2] - jobId
 		// args[3] - agreementId
 		const hasAgreementId = args.length === 4;
-		
-		const dataDdo = await this.aquarius.waitForIndexer(args[1],null,null, this.indexingParams.retryInterval, this.indexingParams.maxRetries);
+
+		const dataDdo = await this.aquarius.waitForIndexer(
+			args[1],
+			null,
+			null,
+			this.indexingParams.retryInterval,
+			this.indexingParams.maxRetries
+		);
 		if (!dataDdo) {
 			console.error(
 				"Error fetching DDO " + args[1] + ".  Does this asset exists?"
 			);
 			return;
 		}
-		const jobId = args[2]
+		const jobId = args[2];
 		let agreementId = null;
-		if(hasAgreementId) {
+		if (hasAgreementId) {
 			agreementId = args[3];
 		}
-		const providerURI =
-			this.oceanNodeUrl && dataDdo.chainId === 8996
-				? this.oceanNodeUrl
-				: dataDdo.services[0].serviceEndpoint;
 
 		const jobStatus = (await ProviderInstance.computeStatus(
-			providerURI,
+			this.oceanNodeUrl,
 			await this.signer.getAddress(),
 			jobId,
 			agreementId
@@ -843,7 +915,6 @@ export class Commands {
 	}
 
 	public async downloadJobResults(args: string[]) {
-	
 		const jobResult = await ProviderInstance.getComputeResultUrl(
 			this.oceanNodeUrl,
 			this.signer,
@@ -853,8 +924,12 @@ export class Commands {
 		console.log("jobResult ", jobResult);
 
 		try {
-			const path = args[3] ? args[3] : '.';
-			const { filename } = await downloadFile(jobResult, path, parseInt(args[2]));
+			const path = args[3] ? args[3] : ".";
+			const { filename } = await downloadFile(
+				jobResult,
+				path,
+				parseInt(args[2])
+			);
 			console.log("File downloaded successfully:", path + "/" + filename);
 		} catch (e) {
 			console.log(`Download url dataset failed: ${e}`);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -33,26 +33,23 @@ export class Commands {
 	public signer: Signer;
 	public config: Config;
 	public aquarius: Aquarius;
-	public providerUrl: string;
+	public oceanNodeUrl: string;
 	// optional settings for indexing wait time
 	private indexingParams: IndexerWaitParams;
 
 	constructor(signer: Signer, network: string | number, config?: Config) {
 		this.signer = signer;
 		this.config = config || new ConfigHelper().getConfig(network);
-		this.providerUrl = process.env.NODE_URL;
+		this.oceanNodeUrl = process.env.NODE_URL;
 		this.indexingParams = getIndexingWaitSettings();
-
-		console.log("Using Provider :", this.providerUrl);
-		this.config.metadataCacheUri = this.providerUrl;
-		
+		console.log("Using Ocean Node URL :", this.oceanNodeUrl);
+		this.config.metadataCacheUri = this.oceanNodeUrl;
 		this.aquarius = new Aquarius(this.config.metadataCacheUri);
-		console.log("Using Aquarius :", this.config.metadataCacheUri);
 	}
 
 	public async start() {
 		console.log('Starting the interactive CLI flow...\n\n');
-		const data = await interactiveFlow(this.providerUrl); // Collect data via CLI
+		const data = await interactiveFlow(this.oceanNodeUrl); // Collect data via CLI
 		await publishAsset(data, this.signer, this.config); // Publish asset with collected data
 	  }
 
@@ -83,7 +80,7 @@ export class Commands {
 				this.signer,
 				asset.services[0].files,
 				asset,
-				this.providerUrl,
+				this.oceanNodeUrl,
 				this.config,
 				this.aquarius,
 				encryptDDO
@@ -114,7 +111,7 @@ export class Commands {
 					this.signer,
 					algoAsset.services[0].files,
 					algoAsset,
-					this.providerUrl,
+					this.oceanNodeUrl,
 					this.config,
 					this.aquarius,
 					encryptDDO
@@ -156,7 +153,7 @@ export class Commands {
 		const updateAssetTx = await updateAssetMetadata(
 			this.signer,
 			asset,
-			this.providerUrl,
+			this.oceanNodeUrl,
 			this.aquarius,
 			encryptDDO
 		);
@@ -185,8 +182,8 @@ export class Commands {
 		}
 
 		const providerURI =
-			this.providerUrl && dataDdo.chainId === 8996
-				? this.providerUrl
+			this.oceanNodeUrl && dataDdo.chainId === 8996
+				? this.oceanNodeUrl
 				: dataDdo.services[0].serviceEndpoint;
 		console.log("Downloading asset using provider: ", providerURI);
 		const datatoken = new Datatoken(this.signer, this.config.chainId, this.config);
@@ -262,10 +259,10 @@ export class Commands {
 			console.error("Not all the data ddos are available.");
 			return;
 		}
-		let providerURI = this.providerUrl
+		let providerURI = this.oceanNodeUrl
 		if(ddos.length > 0) {
-			providerURI = this.providerUrl && ddos[0].chainId === 8996
-			? this.providerUrl
+			providerURI = this.oceanNodeUrl && ddos[0].chainId === 8996
+			? this.oceanNodeUrl
 			: ddos[0].services[0].serviceEndpoint;
 		}
 			
@@ -278,7 +275,7 @@ export class Commands {
 			return;
 		}
 
-		const computeEnvs = await ProviderInstance.getComputeEnvironments(this.providerUrl);
+		const computeEnvs = await ProviderInstance.getComputeEnvironments(this.oceanNodeUrl);
 
 		if(!computeEnvs || computeEnvs.length  < 1) {
 			console.error(
@@ -495,10 +492,10 @@ export class Commands {
 			console.error("Not all the data ddos are available.");
 			return;
 		}
-		let providerURI = this.providerUrl
+		let providerURI = this.oceanNodeUrl
 		if(ddos.length > 0) {
-			providerURI = this.providerUrl && ddos[0].chainId === 8996
-			? this.providerUrl
+			providerURI = this.oceanNodeUrl && ddos[0].chainId === 8996
+			? this.oceanNodeUrl
 			: ddos[0].services[0].serviceEndpoint;
 		}
 			
@@ -510,7 +507,7 @@ export class Commands {
 			return;
 		}
 
-		const computeEnvs = await ProviderInstance.getComputeEnvironments(this.providerUrl);
+		const computeEnvs = await ProviderInstance.getComputeEnvironments(this.oceanNodeUrl);
 
 		if(!computeEnvs || computeEnvs.length  < 1) {
 			console.error(
@@ -633,8 +630,8 @@ export class Commands {
 		}
 
 		const providerURI =
-			this.providerUrl && dataDdo.chainId === 8996
-				? this.providerUrl
+			this.oceanNodeUrl && dataDdo.chainId === 8996
+				? this.oceanNodeUrl
 				: dataDdo.services[0].serviceEndpoint;
 
 		const jobStatus = await ProviderInstance.computeStop(
@@ -649,7 +646,7 @@ export class Commands {
 	}
 
 	public async getComputeEnvironments() {
-		const computeEnvs = await ProviderInstance.getComputeEnvironments(this.providerUrl);
+		const computeEnvs = await ProviderInstance.getComputeEnvironments(this.oceanNodeUrl);
 
 		if(!computeEnvs || computeEnvs.length  < 1) {
 			console.error(
@@ -662,7 +659,7 @@ export class Commands {
 
 	public async computeStreamableLogs(args: string[]) {
 		const jobId = args[0]
-		const logsResponse = await ProviderInstance.computeStreamableLogs(this.providerUrl,this.signer,jobId,
+		const logsResponse = await ProviderInstance.computeStreamableLogs(this.oceanNodeUrl,this.signer,jobId,
 		);
 		console.log('response: ' , logsResponse)
 
@@ -743,7 +740,7 @@ export class Commands {
 			const txid = await updateAssetMetadata(
 				this.signer,
 				asset,
-				this.providerUrl,
+				this.oceanNodeUrl,
 				this.aquarius,
 				encryptDDO
 			);
@@ -806,7 +803,7 @@ export class Commands {
 		const txid = await updateAssetMetadata(
 			this.signer,
 			asset,
-			this.providerUrl,
+			this.oceanNodeUrl,
 			this.aquarius,
 			encryptDDO
 		);
@@ -832,8 +829,8 @@ export class Commands {
 			agreementId = args[3];
 		}
 		const providerURI =
-			this.providerUrl && dataDdo.chainId === 8996
-				? this.providerUrl
+			this.oceanNodeUrl && dataDdo.chainId === 8996
+				? this.oceanNodeUrl
 				: dataDdo.services[0].serviceEndpoint;
 
 		const jobStatus = (await ProviderInstance.computeStatus(
@@ -848,7 +845,7 @@ export class Commands {
 	public async downloadJobResults(args: string[]) {
 	
 		const jobResult = await ProviderInstance.getComputeResultUrl(
-			this.providerUrl,
+			this.oceanNodeUrl,
 			this.signer,
 			args[1],
 			parseInt(args[2])

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -111,7 +111,7 @@ export async function createAssetUtil(
 	owner: Signer,
 	assetUrl: any,
 	ddo: any,
-	providerUrl: string,
+	oceanNodeUrl: string,
 	config: Config,
 	aquariusInstance: Aquarius,
 	encryptDDO: boolean = true,
@@ -120,7 +120,6 @@ export async function createAssetUtil(
 	accessListFactory?: string,
 	allowAccessList?: string,
 	denyAccessList?: string,
-	macOsProviderUrl?: string,
 	
 ) {
 	const isAddress = typeof templateIDorAddress === 'string'
@@ -144,9 +143,9 @@ export async function createAssetUtil(
 			await owner.getAddress(),
 			[await owner.getAddress(), ZERO_ADDRESS]
 		)
-		return await createAsset(name, symbol, signer, assetUrl, templateIDorAddress, ddo, encryptDDO, providerUrl || macOsProviderUrl, providerFeeToken, aquariusInstance, accessListFactory, allowAccessList, denyAccessList);
+		return await createAsset(name, symbol, signer, assetUrl, templateIDorAddress, ddo, encryptDDO, oceanNodeUrl, providerFeeToken, aquariusInstance, accessListFactory, allowAccessList, denyAccessList);
 	}
-	return await createAsset(name, symbol, signer, assetUrl, templateIDorAddress, ddo, encryptDDO, providerUrl || macOsProviderUrl, providerFeeToken, aquariusInstance);
+	return await createAsset(name, symbol, signer, assetUrl, templateIDorAddress, ddo, encryptDDO, oceanNodeUrl, providerFeeToken, aquariusInstance);
 }
 
 
@@ -154,20 +153,19 @@ export async function createAssetUtil(
 export async function updateAssetMetadata(
 	owner: Signer,
 	updatedDdo: DDO,
-	providerUrl: string,
+	oceanNodeUrl: string,
 	aquariusInstance: Aquarius,
-	macOsProviderUrl?: string,
 	encryptDDO: boolean = true
 ): Promise<any> {
 	const nft = new Nft(owner, (await owner.provider.getNetwork()).chainId);
 	let flags;
 	let metadata;
-	const validateResult = await aquariusInstance.validate(updatedDdo, owner, providerUrl || macOsProviderUrl);
+	const validateResult = await aquariusInstance.validate(updatedDdo, owner, oceanNodeUrl);
 	if (encryptDDO) {
 		const providerResponse = await ProviderInstance.encrypt(
 			updatedDdo,
 			updatedDdo.chainId,
-			macOsProviderUrl || providerUrl
+			oceanNodeUrl
 		);
 		metadata = await providerResponse;
 		flags = 2
@@ -183,7 +181,7 @@ export async function updateAssetMetadata(
 		updatedDdo.nftAddress,
 		await owner.getAddress(),
 		0,
-		providerUrl,
+		oceanNodeUrl,
 		"",
 		ethers.utils.hexlify(flags),
 		metadata,
@@ -201,7 +199,7 @@ export async function handleComputeOrder(
 	datatoken: Datatoken,
 	config: Config,
 	providerFees: ProviderFees,
-	providerUrl: string,
+	oceanNodeUrl: string,
 	consumeMarkerFee?: ConsumeMarketFee
 ) {
 	/* We do have 3 possible situations:
@@ -240,7 +238,7 @@ export async function handleComputeOrder(
 		payerAccount,
 		config,
 		datatoken,
-		providerUrl,
+		oceanNodeUrl,
 		consumerAddress,
 		consumeMarkerFee,
 		providerFees
@@ -324,12 +322,7 @@ export function isPrivateIP(ip): boolean {
  }
 
  export async function getMetadataURI() {
-	let metadataURI
-	if (!process.env.AQUARIUS_URL || (process.env.AQUARIUS_URL && process.env.NODE_URL)) {
-		metadataURI = process.env.NODE_URL
-	} else {
-		metadataURI = process.env.AQUARIUS_URL
-	}
+	const metadataURI = process.env.NODE_URL
 	const parsed = new URL(metadataURI);
 	let ip = metadataURI // by default
 	// has port number?

--- a/test/consumeFlow.test.ts
+++ b/test/consumeFlow.test.ts
@@ -57,8 +57,7 @@ describe("Ocean CLI Publishing", function() {
         process.env.PRIVATE_KEY = "0x1d751ded5a32226054cd2e71261039b65afb9ee1c746d055dd699b1150a5befc";
         // Using this account: 0x529043886F21D9bc1AE0feDb751e34265a246e47
         process.env.RPC = "http://127.0.0.1:8545";
-        process.env.AQUARIUS_URL = "http://127.0.0.1:8001";
-        process.env.PROVIDER_URL = "http://127.0.0.1:8001";
+        process.env.NODE_URL = "http://127.0.0.1:8001";
         process.env.ADDRESS_FILE = path.join(process.env.HOME || "", ".ocean/ocean-contracts/artifacts/address.json");
 
         exec(`npm run cli publish ${metadataFile}`, { cwd: projectRoot }, (error, stdout) => {

--- a/test/interactivePublishFlow.ts
+++ b/test/interactivePublishFlow.ts
@@ -16,8 +16,7 @@ describe("Ocean CLI Interactive Publishing", function() {
     it("should publish an asset using 'npm run cli start' interactive flow", function(done) {
         process.env.PRIVATE_KEY = "0x1d751ded5a32226054cd2e71261039b65afb9ee1c746d055dd699b1150a5befc";
         process.env.RPC = "http://127.0.0.1:8545";
-        process.env.AQUARIUS_URL = "http://127.0.0.1:8001";
-        process.env.PROVIDER_URL = "http://127.0.0.1:8001";
+        process.env.NODE_URL = "http://127.0.0.1:8001";
         process.env.ADDRESS_FILE = path.join(process.env.HOME || "", ".ocean/ocean-contracts/artifacts/address.json");
 
         const child = exec(`npm run cli start`, { cwd: projectRoot });


### PR DESCRIPTION
Fixes #110 .

Changes proposed in this PR:

- get rid of PROVIDER_URL and AQUARIUS_URL, since we have single NODE_URL now
- 
- 