### PR TITLE
fix interactive menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ Instead of a DID, you can pass a full `ComputeAsset` (datasets) or `ComputeAlgor
 
   `npm run cli getComputeEnvironments`
 
+  Optionally pass a specific Ocean Node URL or peer id to query instead of `NODE_URL`:
+
+  `npm run cli getComputeEnvironments <nodeUrlOrPeerId>`
+
 ---
 
 **Get Compute Streamable Logs:**
@@ -431,6 +435,80 @@ Instead of a DID, you can pass a full `ComputeAsset` (datasets) or `ComputeAlgor
 
 ---
 
+**Allow Algorithm on Dataset:**
+
+- **Positional:**  
+  `npm run cli allowAlgo did:op:dataset did:op:algo`
+
+- **Named Options:**  
+  `npm run cli allowAlgo --dataset did:op:dataset --algo did:op:algo --encrypt true`
+
+- Approves an algorithm to run on a compute-enabled dataset (signer must be the dataset NFT owner).
+
+---
+
+**Create Bucket:**
+
+  `npm run cli createBucket`
+
+- Creates a new persistent-storage bucket on the node. Pass an access-list contract address to gate it; omit for owner-only access:
+
+  `npm run cli createBucket 0x1234...accessListAddress`
+
+---
+
+**Add File to Bucket:**
+
+  `npm run cli addFileToBucket <bucketId> ./path/to/file.csv`
+
+- Optionally pass a name to store the file under (defaults to the file's basename):
+
+  `npm run cli addFileToBucket <bucketId> ./path/to/file.csv results.csv`
+
+---
+
+**List Buckets:**
+
+  `npm run cli listBuckets`
+
+- Lists buckets owned by the signer, or by a specific owner:
+
+  `npm run cli listBuckets --owner 0x1234...ownerAddress`
+
+---
+
+**List Files in Bucket:**
+
+  `npm run cli listFilesInBucket <bucketId>`
+
+---
+
+**Get File Object:**
+
+  `npm run cli getFileObject <bucketId> <fileName>`
+
+- Returns the file-object descriptor for a file in a bucket.
+
+---
+
+**Delete File:**
+
+  `npm run cli deleteFile <bucketId> <fileName>`
+
+---
+
+**Download Node Logs (admin):**
+
+- **Positional:**  
+  `npm run cli downloadNodeLogs ./logs 24`
+
+- **Named Options:**  
+  `npm run cli downloadNodeLogs --output ./logs --last 24`
+
+- Downloads node logs into `<output>/logs.json`. Use either `last` (hours from now) **or** a `from`/`to` epoch-ms range. `maxLogs` caps the number of entries (default: 100, max: 1000). Requires admin privileges on the node.
+
+---
+
 #### Available Named Options Per Command
 
 - **getDDO:**  
@@ -453,6 +531,11 @@ Instead of a DID, you can pass a full `ComputeAsset` (datasets) or `ComputeAlgor
   `-d, --did <did>`  
   `-f, --folder [destinationFolder]` (Default: `.`)
   `-s, --service <serviceId>` (Optional, target a specific service)
+
+- **allowAlgo:**  
+  `-d, --dataset <datasetDid>`  
+  `-a, --algo <algoDid>`  
+  `-e, --encrypt [boolean]` (Default: `true`)
 
 
 - **startCompute:**
@@ -477,6 +560,7 @@ Instead of a DID, you can pass a full `ComputeAsset` (datasets) or `ComputeAlgor
   `-x, --algo-service [algoServiceId]` (Optional, override algorithm service)
 
 - **getComputeEnvironments:**  
+  `-n, --node [node]` (Optional. Ocean Node URL or peer id to query; defaults to `NODE_URL`)
 
 - **computeStreamableLogs:**  
 
@@ -543,6 +627,31 @@ Instead of a DID, you can pass a full `ComputeAsset` (datasets) or `ComputeAlgor
 - **removeFromAccessList:**  
   `-a, --address <accessListAddress>`  
   `-u, --users <users>`
+
+- **createBucket:**  
+  Positional only: `[accessListAddress]` (optional; omit for owner-only access)
+
+- **addFileToBucket:**  
+  Positional only: `<bucketId> <filePath> [fileName]`
+
+- **listBuckets:**  
+  `-o, --owner <address>` (Optional; defaults to signer)
+
+- **listFilesInBucket:**  
+  Positional only: `<bucketId>`
+
+- **getFileObject:**  
+  Positional only: `<bucketId> <fileName>`
+
+- **deleteFile:**  
+  Positional only: `<bucketId> <fileName>`
+
+- **downloadNodeLogs:**  
+  `-o, --output <output>`  
+  `-l, --last [last]` (Hours from now; use either `last` or `from`/`to`)  
+  `-f, --from [from]` (Start time, epoch ms)  
+  `-t, --to [to]` (End time, epoch ms)  
+  `-m, --maxLogs [maxLogs]` (Default: 100, max: 1000)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -440,8 +440,10 @@ Instead of a DID, you can pass a full `ComputeAsset` (datasets) or `ComputeAlgor
 - **Positional:**  
   `npm run cli allowAlgo did:op:dataset did:op:algo`
 
-- **Named Options:**  
-  `npm run cli allowAlgo --dataset did:op:dataset --algo did:op:algo --encrypt true`
+- **With named option:**  
+  `npm run cli allowAlgo did:op:dataset did:op:algo --encrypt true`
+
+- The dataset and algorithm DIDs are required positional arguments (`--dataset` / `--algo` may override them, but the positionals must still be supplied). `--encrypt` toggles DDO encryption (default: `true`).
 
 - Approves an algorithm to run on a compute-enabled dataset (signer must be the dataset NFT owner).
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "author": "Ocean Protocol <devops@oceanprotocol.com>",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=22"
+  },
   "bugs": {
     "url": "https://github.com/oceanprotocol/ocean.js-cli/issues"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -466,11 +466,16 @@ export async function createCLI() {
   program
     .command("getComputeEnvironments")
     .alias("getC2DEnvs")
+    .argument(
+      "[node]",
+      "Optional Ocean Node URL or peer id to query (defaults to NODE_URL)"
+    )
+    .option("-n, --node [node]", "Ocean Node URL or peer id to query")
     .description("Gets the existing compute environments")
-    .action(async () => {
+    .action(async (node, options) => {
       const { signer, chainId } = await initializeSigner();
       const commands = new Commands(signer, chainId);
-      await commands.getComputeEnvironments();
+      await commands.getComputeEnvironments(options.node || node);
     });
 
   // computeStreamableLogs command

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -470,7 +470,7 @@ export async function createCLI() {
       "[node]",
       "Optional Ocean Node URL or peer id to query (defaults to NODE_URL)"
     )
-    .option("-n, --node [node]", "Ocean Node URL or peer id to query")
+    .option("-n, --node <node>", "Ocean Node URL or peer id to query")
     .description("Gets the existing compute environments")
     .action(async (node, options) => {
       const { signer, chainId } = await initializeSigner();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1140,10 +1140,9 @@ export class Commands {
     console.log(jobStatus);
   }
 
-  public async getComputeEnvironments() {
-    const computeEnvs = await ProviderInstance.getComputeEnvironments(
-      this.oceanNodeUrl
-    );
+  public async getComputeEnvironments(nodeUrlOverride?: string) {
+    const nodeUrl = nodeUrlOverride || this.oceanNodeUrl;
+    const computeEnvs = await ProviderInstance.getComputeEnvironments(nodeUrl);
 
     if (!computeEnvs || computeEnvs.length < 1) {
       console.error(
@@ -1152,7 +1151,7 @@ export class Commands {
       return;
     }
 
-    console.log("Exiting compute environments: ", JSON.stringify(computeEnvs));
+    console.log("Existing compute environments: ", JSON.stringify(computeEnvs));
   }
 
   public async computeStreamableLogs(args: string[]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,18 @@ let program: Command
 const supportedCommands: string[] = []
 
 /**
- * Make Commander throw instead of calling process.exit on errors / help /
- * version. This must be applied to every subcommand, not just the root program:
- * a subcommand parse error (e.g. a missing required argument) is raised by the
- * subcommand itself, which would otherwise kill the whole REPL process.
+ * Prepare commander for REPL use: make it throw instead of calling process.exit
+ * on errors / help / version, and colorize its own error output (e.g. "missing
+ * required argument"). Both must be applied to every subcommand, not just the
+ * root program: a subcommand parse error is raised and written by the subcommand
+ * itself, which would otherwise kill the REPL and print an uncolored message.
  */
-function enableExitOverride(cmd: Command): void {
+function configureForLoop(cmd: Command): void {
 	cmd.exitOverride()
-	for (const sub of cmd.commands) enableExitOverride(sub)
+	cmd.configureOutput({
+		outputError: (str, write) => write(chalk.red(str)),
+	})
+	for (const sub of cmd.commands) configureForLoop(sub)
 }
 
 /**
@@ -169,8 +173,8 @@ async function main(): Promise<void> {
 		}
 
 		// In loop mode, commander must throw (not exit) on any error so a bad
-		// command never terminates the REPL.
-		enableExitOverride(program)
+		// command never terminates the REPL, and its errors are colorized.
+		configureForLoop(program)
 
 		// Run the initial command passed on argv once (if any), surfacing errors.
 		const initialTokens = process.argv.slice(2)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,110 +1,185 @@
-import { sleep } from '@oceanprotocol/lib';
-import {createInterface} from "readline";
+import { Command, CommanderError } from "commander";
+import { stdin as input, stdout as output } from "node:process";
+import { createInterface } from "readline/promises";
 import { createCLI } from './cli.js';
 
 let program
-let exit = false
-const supportedCommands: string[] = [] 
-const initializeCommands: string[] = []
+const supportedCommands: string[] = []
 
-async function waitForCommands() {
-  const commandLine = await readLine("Enter command ('exit' | 'quit' or CTRL-C to terminate'):\n")
-  let command = null
-  if(commandLine === "quit" || commandLine === "exit" || commandLine === "\\q") {
-	exit = true
-	return
-  }
+/**
+ * Make Commander throw instead of calling process.exit on errors / help /
+ * version. This must be applied to every subcommand, not just the root program:
+ * a subcommand parse error (e.g. a missing required argument) is raised by the
+ * subcommand itself, which would otherwise kill the whole REPL process.
+ */
+function enableExitOverride(cmd: Command): void {
+	cmd.exitOverride()
+	for (const sub of cmd.commands) enableExitOverride(sub)
+}
 
-  const commandSplitted: string[] = commandLine.split(" ")
-  if(commandSplitted.length < 1) {
-	console.log("Invalid command, missing one or more arguments!")
-	return
-  }
+/**
+ * Split a command line into tokens while honoring single/double quotes, so that
+ * JSON arguments (e.g. startCompute resources/datasets) survive intact. Runs of
+ * whitespace collapse and produce no empty tokens.
+ */
+function tokenize(line: string): string[] {
+	const tokens: string[] = []
+	let current = ""
+	let quote: string | null = null
+	let hasContent = false
 
-  if(commandSplitted.length>=3) {
-	if(commandSplitted[0] === "npm" && commandSplitted[1] === "run" && commandSplitted[2] === "cli") {
-		commandSplitted.splice(0,3)
-		command = commandSplitted.join(" ")
+	for (const ch of line) {
+		if (quote) {
+			if (ch === quote) {
+				quote = null
+			} else {
+				current += ch
+			}
+		} else if (ch === '"' || ch === "'") {
+			quote = ch
+			hasContent = true
+		} else if (ch === " " || ch === "\t") {
+			if (hasContent) {
+				tokens.push(current)
+				current = ""
+				hasContent = false
+			}
+		} else {
+			current += ch
+			hasContent = true
+		}
 	}
-  } else if(commandSplitted.length >= 1) {
-	// just the command without npm run cli
-	command = commandSplitted[0]
-  }
+	if (hasContent) tokens.push(current)
+	return tokens
+}
 
-  if(command && command.length > 0 && commandSplitted.length>0) {
-	const commandName = commandSplitted[0]
-	const args = initializeCommands.concat(commandSplitted)
+/**
+ * Strip an optional leading `npm run cli` prefix so that a pasted example
+ * command behaves identically to the bare command form.
+ */
+function stripNpmPrefix(tokens: string[]): string[] {
+	if (tokens[0] === "npm" && tokens[1] === "run" && tokens[2] === "cli") {
+		return tokens.slice(3)
+	}
+	return tokens
+}
 
-	if(!supportedCommands.includes(commandName)) {
-		console.log("Invalid option: ", commandName)
+/**
+ * Run a single already-tokenized command through commander. `from: 'user'`
+ * tells commander the tokens are raw user args (no node/script prefix), so bare
+ * start and initial-command start behave identically. Errors never terminate the
+ * REPL: commander parse errors / help / version already write their own output,
+ * so only unexpected runtime (action) errors are surfaced here.
+ */
+async function runTokens(tokens: string[]): Promise<void> {
+	if (tokens.length === 0) return
+
+	// Let commander handle option-style tokens (e.g. --help, --version); only
+	// reject unknown command names.
+	const commandName = tokens[0]
+	if (!commandName.startsWith("-") && !supportedCommands.includes(commandName)) {
+		console.log(`Invalid option: ${commandName}. Type 'help' to see the available commands.`)
 		return
-	} 
-	
-	try {
-		await program.parseAsync(args);
-	}catch(error) {
-		console.log('Command error: ', error)
 	}
-  } 
-  
+
+	try {
+		await program.parseAsync(tokens, { from: "user" })
+	} catch (error) {
+		// CommanderError (missing/excess args, unknown option, help, version) is
+		// already reported by commander itself — don't double-print it.
+		if (!(error instanceof CommanderError)) {
+			console.error("Command error:", error?.message ?? error)
+		}
+	}
 }
 
-async function readLine(question: string): Promise<string> {
+const PROMPT = "Enter command ('exit' | 'quit' or CTRL-C to terminate):\n"
 
-    const readLine = createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
-
-    let answer = ""
-    readLine.question(question, (it: string) => { 
-    answer = it.trim()
-    readLine.close()
-    })
-    while (answer == "") { await sleep(100)  }
-
-    return answer
-
+/**
+ * Tab-completion for the command name (the first token only). readline completes
+ * to the longest common prefix of the matches, or lists them when there is more
+ * than one. Returns all known commands when the line is still empty.
+ */
+function completer(line: string): [string[], string] {
+	// Only complete the command name, not its arguments.
+	if (line.includes(" ")) return [[], line]
+	const hits = supportedCommands.filter((name) => name.startsWith(line)).sort()
+	return [hits, line]
 }
+
+/**
+ * Read commands from stdin until the user exits or input is exhausted (EOF).
+ *
+ * A single persistent readline interface is consumed via its async iterator so
+ * that backpressure is respected and no buffered lines are dropped — creating a
+ * fresh interface per prompt silently discards piped input beyond the first
+ * line. The interface is paused around command execution so it never competes
+ * for stdin with an interface a command opens itself (e.g. the payment
+ * confirmation prompt in cli.ts).
+ */
+async function runLoop(): Promise<void> {
+	const rl = createInterface({ input, output, completer })
+	rl.setPrompt(PROMPT)
+	rl.prompt()
+
+	for await (const rawLine of rl) {
+		const line = rawLine.trim()
+
+		if (line === "quit" || line === "exit" || line === "\\q") {
+			break
+		}
+
+		// Empty input: re-prompt instead of busy-waiting or dropping the session.
+		if (line === "") {
+			rl.prompt()
+			continue
+		}
+
+		const tokens = stripNpmPrefix(tokenize(line))
+		rl.pause()
+		await runTokens(tokens)
+		rl.resume()
+		rl.prompt()
+	}
+
+	rl.close()
+}
+
 async function main() {
 	try {
 		program = await createCLI();
-		for(const command of program.commands) {
+		for (const command of program.commands) {
 			supportedCommands.push(command.name())
-			supportedCommands.push(command.alias())
+			const alias = command.alias()
+			if (alias) supportedCommands.push(alias)
 		}
-		
-		console.log("Type 'exit' or 'quit' or 'CTRL-C' to terminate process")
+
 		// Handle help command without initializing signer
 		if (process.argv.includes('--help') || process.argv.includes('-h')) {
 			program.outputHelp();
 		}
 
-		const initialCommandLine:string [] = process.argv
-		if(process.env.AVOID_LOOP_RUN !== 'true') {
-			
-			do {
-				program.exitOverride();
-				try {
-					if(initializeCommands.length === 0 && initialCommandLine.length > 2) {
-						initializeCommands.push(initialCommandLine[0]) // node
-						initializeCommands.push(initialCommandLine[1]) // file path
-						// just once
-						await program.parseAsync(initialCommandLine);
-					}
-				}catch(err) {
-					// silently ignore
-				}
-				await waitForCommands()
-			}while(!exit)
-		} else {
+		if (process.env.AVOID_LOOP_RUN === 'true') {
 			// one shot
-			await program.parseAsync(initialCommandLine);
+			await program.parseAsync(process.argv);
+			return
 		}
+
+		// In loop mode, commander must throw (not exit) on any error so a bad
+		// command never terminates the REPL.
+		enableExitOverride(program)
+
+		// Run the initial command passed on argv once (if any), surfacing errors.
+		const initialTokens = process.argv.slice(2)
+		if (initialTokens.length > 0) {
+			await runTokens(initialTokens)
+		}
+
+		// Then loop on stdin until the user exits or input is exhausted.
+		await runLoop()
 
 	} catch (error) {
 		console.error('Program Error:', error.message);
-		exit = true
 		process.exit(1);
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,9 +154,11 @@ async function main() {
 			if (alias) supportedCommands.push(alias)
 		}
 
-		// Handle help command without initializing signer
+		// Handle help flag without initializing signer, and exit so it prints
+		// once (not again via parseAsync/runLoop below).
 		if (process.argv.includes('--help') || process.argv.includes('-h')) {
 			program.outputHelp();
+			return;
 		}
 
 		if (process.env.AVOID_LOOP_RUN === 'true') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import { Command, CommanderError } from "commander";
+import chalk from "chalk";
 import { stdin as input, stdout as output } from "node:process";
 import { createInterface } from "readline/promises";
 import { createCLI } from './cli.js';
 
-let program
+let program: Command
 const supportedCommands: string[] = []
 
 /**
@@ -78,7 +79,7 @@ async function runTokens(tokens: string[]): Promise<void> {
 	// reject unknown command names.
 	const commandName = tokens[0]
 	if (!commandName.startsWith("-") && !supportedCommands.includes(commandName)) {
-		console.log(`Invalid option: ${commandName}. Type 'help' to see the available commands.`)
+		console.log(chalk.red(`Invalid option: ${commandName}. Type 'help' to see the available commands.`))
 		return
 	}
 
@@ -88,7 +89,7 @@ async function runTokens(tokens: string[]): Promise<void> {
 		// CommanderError (missing/excess args, unknown option, help, version) is
 		// already reported by commander itself — don't double-print it.
 		if (!(error instanceof CommanderError)) {
-			console.error("Command error:", error?.message ?? error)
+			console.error(chalk.red(`Command error: ${error?.message ?? error}`))
 		}
 	}
 }
@@ -145,7 +146,7 @@ async function runLoop(): Promise<void> {
 	rl.close()
 }
 
-async function main() {
+async function main(): Promise<void> {
 	try {
 		program = await createCLI();
 		for (const command of program.commands) {
@@ -181,7 +182,7 @@ async function main() {
 		await runLoop()
 
 	} catch (error) {
-		console.error('Program Error:', error.message);
+		console.error(chalk.red(`Program Error: ${error.message}`));
 		process.exit(1);
 	}
 }

--- a/test/paidComputeFlow.test.ts
+++ b/test/paidComputeFlow.test.ts
@@ -121,7 +121,7 @@ describe("Ocean CLI Paid Compute", function() {
      it("should get compute environments using 'npm run cli getComputeEnvironments'", async function() {
         const output = await runCommand(`npm run cli getComputeEnvironments`);
 
-		const jsonMatch = output.match(/Exiting compute environments:\s*([\s\S]*)/);
+		const jsonMatch = output.match(/Existing compute environments:\s*([\s\S]*)/);
 		if (!jsonMatch) {
 			console.error("Raw output:", output);
 			throw new Error("Could not find compute environments in the output");

--- a/test/replMenu.test.ts
+++ b/test/replMenu.test.ts
@@ -1,0 +1,128 @@
+import { expect } from "chai";
+import { spawn } from "child_process";
+import path from "path";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..");
+
+// Recurring prompt string emitted by the REPL (keep in sync with src/index.ts).
+const PROMPT = "Enter command ('exit' | 'quit' or CTRL-C to terminate):\n";
+
+/**
+ * Drive the interactive REPL (menu mode) with piped stdin.
+ *
+ * These tests are infra-free: PRIVATE_KEY/RPC/NODE_URL point at an unreachable
+ * port, so a command that actually parses and runs surfaces a "Command error"
+ * (connection refused) while a command that is dropped or rejected at parse time
+ * does not. AVOID_LOOP_RUN is left unset so the process enters the REPL loop.
+ */
+function runRepl(
+  inputLines: string[],
+  extraArgs: string[] = []
+): Promise<{ output: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const env = { ...process.env };
+    delete env.AVOID_LOOP_RUN;
+    env.PRIVATE_KEY =
+      "0x1d751ded5a32226054cd2e71261039b65afb9ee1c746d055dd699b1150a5befc";
+    env.RPC = "http://127.0.0.1:1";
+    env.NODE_URL = "http://127.0.0.1:1";
+
+    const child = spawn("npx", ["tsx", "src/index.ts", ...extraArgs], {
+      cwd: projectRoot,
+      env,
+    });
+
+    let output = "";
+    child.stdout.on("data", (d) => (output += d.toString()));
+    child.stderr.on("data", (d) => (output += d.toString()));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ output, code }));
+
+    for (const line of inputLines) {
+      child.stdin.write(line + "\n");
+    }
+    child.stdin.end();
+  });
+}
+
+describe("Ocean CLI interactive menu (REPL)", function () {
+  this.timeout(60000);
+
+  it("runs a single-token command on bare start", async function () {
+    const { output } = await runRepl(["getComputeEnvironments", "exit"]);
+    // Parsed and executed (fails at the network, not at parsing).
+    expect(output).to.contain("Command error");
+    expect(output).to.not.contain("Invalid option");
+  });
+
+  it("runs a multi-argument command instead of silently dropping it", async function () {
+    const { output } = await runRepl(["download did:op:123 /tmp/x", "exit"]);
+    expect(output).to.contain("Command error");
+    expect(output).to.not.contain("Invalid option");
+  });
+
+  it("accepts a line typed with the 'npm run cli' prefix", async function () {
+    const { output } = await runRepl([
+      "npm run cli getComputeEnvironments",
+      "exit",
+    ]);
+    expect(output).to.contain("Command error");
+    expect(output).to.not.contain("Invalid option");
+  });
+
+  it("keeps a single-quoted JSON argument as one token", async function () {
+    const { output } = await runRepl([
+      `editAsset did:op:1 '{"name": "a b c"}'`,
+      "exit",
+    ]);
+    // If quoting were mishandled the JSON would split into extra tokens and
+    // Commander would reject it with "too many arguments".
+    expect(output).to.not.contain("too many arguments");
+    expect(output).to.contain("Command error");
+  });
+
+  it("re-prompts on empty input instead of hanging", async function () {
+    const { output, code } = await runRepl(["", "", "exit"]);
+    // Reaching this assertion at all means it did not hang (mocha would time out).
+    expect(code).to.equal(0);
+    const prompts = output.split(PROMPT).length - 1;
+    expect(prompts).to.be.greaterThanOrEqual(3);
+  });
+
+  it("reports an unknown command and suggests help", async function () {
+    const { output } = await runRepl(["definitelyNotACommand", "exit"]);
+    expect(output).to.contain("Invalid option: definitelyNotACommand");
+  });
+
+  it("survives a command with a missing required argument", async function () {
+    // getDDO requires <did>; the parse error must not terminate the REPL, and a
+    // subsequent command must still run.
+    const { output, code } = await runRepl([
+      "getDDO",
+      "definitelyNotACommand",
+      "exit",
+    ]);
+    expect(output).to.contain("missing required argument");
+    // Proof the loop kept going after the parse error:
+    expect(output).to.contain("Invalid option: definitelyNotACommand");
+    expect(code).to.equal(0);
+  });
+
+  it("exits cleanly on EOF when 'exit' is never typed", async function () {
+    const { code } = await runRepl(["getComputeEnvironments"]);
+    expect(code).to.equal(0);
+  });
+
+  it("accepts an optional node argument for getComputeEnvironments", async function () {
+    const { output } = await runRepl([
+      "getComputeEnvironments http://127.0.0.1:2",
+      "exit",
+    ]);
+    expect(output).to.not.contain("too many arguments");
+    expect(output).to.contain("Command error");
+  });
+});


### PR DESCRIPTION
# Fix #161 (Interactive menu (REPL) mode)

## Summary

Rewrites the interactive command loop in `src/index.ts`. In menu mode (`npm run cli`
with no `AVOID_LOOP_RUN`), many commands silently failed or behaved differently than
their one-shot equivalents. This PR makes menu mode behave identically to one-shot mode,
fixes several ways the REPL could hang or drop input, and lets `getComputeEnvironments`
accept an optional target node.

## Menu-mode bugs fixed

1. **Bare start broke every menu command.** The fake `node`/script-path prefix that
   Commander's default parsing expects was only populated when the process was started
   *with* an initial command. Starting with plain `npm run cli` left it empty, so the
   first two tokens of every typed command were consumed as "node binary" + "script
   path" and the command dumped help instead of running. Fixed by parsing with
   `{ from: "user" }`, which removes the prefix mechanism entirely — bare start and
   initial-command start now behave the same.

2. **Commands with ≥2 arguments were silently discarded.** Input with ≥3 tokens was
   only handled if it literally began with `npm run cli`; otherwise it was dropped with
   no output. Affected most of the CLI in menu mode (`download`, `startCompute`,
   `editAsset`, `stopCompute`, `authorizeEscrow`, …). Fixed by treating all tokens
   uniformly after stripping an optional `npm run cli` prefix.

3. **An empty Enter bricked the session.** `readLine()` busy-waited
   `while (answer == "")` on an already-closed interface, spinning forever on one empty
   line. Fixed: empty input simply re-prompts.

4. **A command error could kill the whole session.** `exitOverride()` was only set on
   the root program, so a subcommand parse error (e.g. `getDDO` with no `did`) was raised
   by the subcommand itself and called `process.exit(1)`, dropping the user back to the
   shell. `exitOverride()` is now applied recursively to every subcommand, so any parse
   error is caught, reported, and the loop continues waiting for the next command.
   Initial-command failures (previously swallowed by an empty `catch`) are surfaced the
   same way.

5. **Naive tokenization.** `commandLine.split(" ")` could not parse quotes, so JSON
   arguments (`startCompute` resources/datasets, `editAsset` bodies) never worked in the
   menu, and double spaces injected empty tokens. Replaced with a small quote-aware
   tokenizer that honors `"…"` / `'…'` and drops empty tokens. (Wrap JSON in single
   quotes, per the documented convention, so its inner double quotes are preserved.)

New in menu mode:

- **Tab completion for command names.** Typing a prefix and pressing `Tab` completes a
  unique command (e.g. `getComputeE` → `getComputeEnvironments`) or lists the candidates
  when several match (e.g. `get` → `getDDO`, `getComputeEnvironments`, `getJobStatus`, …).
  Completion applies to the command name only, not its arguments.

Also fixed as part of the rewrite:

- **Piped input was truncated.** Reading via a fresh readline interface per prompt
  discards buffered stdin beyond the first line. The loop now uses a single persistent
  interface consumed via its async iterator, which respects backpressure and never drops
  lines — important for scripted/piped usage and the regression tests below.
- **`help` no longer prints a stack trace.** Benign `CommanderError` codes
  (`commander.helpDisplayed`, `commander.help`, `commander.version`) are suppressed;
  real errors are shown.
- **EOF exits cleanly.** When stdin is exhausted without an explicit `exit`, the loop
  terminates instead of hanging.
- **Polish:** `undefined` aliases are no longer pushed into the supported-commands list;
  unknown commands suggest `help`; option-style first tokens (`--help`, `--version`) are
  routed to Commander instead of being rejected as "Invalid option"; the dead
  `length < 1` check was removed. Commander already prints its own message for parse
  errors, so those are no longer double-reported. A single descriptive prompt
  (`Enter command ('exit' | 'quit' or CTRL-C to terminate):`) is shown at startup and
  after every command, with no separate redundant banner.

### Coordination with the payment prompt

The `startCompute` flow opens its own stdin interface for payment confirmation
(`src/cli.ts`). The REPL pauses its interface around command execution so the two never
compete for stdin. (The payment prompt is disabled on non-TTY stdin anyway.)

## `getComputeEnvironments` accepts an optional node

`getComputeEnvironments` (alias `getC2DEnvs`) now takes an optional node argument —
`getComputeEnvironments <nodeUrlOrPeerId>` or `--node <nodeUrlOrPeerId>` — to query a
specific Ocean Node, defaulting to `NODE_URL` when omitted. Previously the command
declared zero arguments, so any extra token (e.g. `getComputeEnvironments peerID`)
hard-errored with "too many arguments" under Commander v13. Every other command keeps
strict excess-argument checking, which gives users a clear error rather than silently
ignoring typos.

## Behavior preserved

- One-shot mode (`AVOID_LOOP_RUN=true`) is unchanged: it still parses `process.argv`
  directly with Commander's default parsing.
- Existing DID/flag usage is unchanged; the new node argument is purely additive.

## Regression tests

Adds `test/replMenu.test.ts`, an infra-free system test that spawns the CLI with piped
stdin and drives the REPL. It points `PRIVATE_KEY`/`RPC`/`NODE_URL` at an unreachable
port, so a command that actually parses and runs surfaces a `Command error` (connection
refused) while a dropped or parse-rejected command does not — letting the test
distinguish "ran" from "silently ignored" without any live node. Covered cases:

- single-token command on bare start
- multi-argument command (previously silently dropped)
- a line typed with the `npm run cli` prefix
- single-quoted JSON argument stays one token (no "too many arguments")
- empty input re-prompts and does not hang
- unknown command reports "Invalid option" and suggests help
- EOF without `exit` terminates cleanly
- `getComputeEnvironments <node>` accepts the optional node argument

## Housekeeping

- Adds an `engines` field (`"node": ">=22"`) to `package.json` so the Node version in
  `.nvmrc` is actually enforced by npm. The wrong Node version silently produces a stale
  `node_modules` / boot failure, which is easy to miss.
- Updates the README `getComputeEnvironments` docs to show the new optional node argument
  and the `-n, --node` option.

## Other verification

- `npm run build:tsc` and `npm run lint` — pass (only pre-existing `no-explicit-any`
  warnings remain; all touched files are clean).
- `resolveComputeInputs` unit test — 11 passing.
- `setup.test.ts` — 4 passing (the `getComputeEnvironments` help line now reads
  `getComputeEnvironments|getC2DEnvs [options] [node]`; existing assertions still hold).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `getComputeEnvironments` now supports targeting a specific node by URL or peer ID.
  - Improved interactive CLI with command validation, quoted-argument handling, tab completion, and support for `npm run cli` prefixes.
  - Added documentation for algorithm permissions, persistent-storage bucket workflows, and node-log downloads.

- **Documentation**
  - Expanded CLI command examples and available option references.

- **Chores**
  - Node.js 22 or newer is now required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->